### PR TITLE
[fix] #128 아카이빙 & 포즈 QA 사항 반영

### DIFF
--- a/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/UserRepository.kt
+++ b/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/UserRepository.kt
@@ -8,6 +8,8 @@ interface UserRepository {
     suspend fun setRandomPoseVisited()
     val hasShownInfoToolTip: Flow<Boolean>
     suspend fun setInfoToolTipShown()
+    val hasShownQRInfoToolTip: Flow<Boolean>
+    suspend fun setQRInfoToolTipShown()
 
     suspend fun getUserInfo(): Result<UserInfo>
     suspend fun updateUserInfo(nickname: String): Result<Unit>

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/UserRepositoryImpl.kt
@@ -41,6 +41,17 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
+    override val hasShownQRInfoToolTip: Flow<Boolean> =
+        dataStore.data.map { preferences ->
+            preferences[HAS_SHOWN_QR_INFO_TOOLTIP] ?: false
+        }
+
+    override suspend fun setQRInfoToolTipShown() {
+        dataStore.edit { preferences ->
+            preferences[HAS_SHOWN_QR_INFO_TOOLTIP] = true
+        }
+    }
+
     override suspend fun getUserInfo(): Result<UserInfo> = runSuspendCatching {
         userService.getUserInfo().data.toModel()
     }
@@ -56,5 +67,6 @@ class UserRepositoryImpl @Inject constructor(
     companion object {
         private val HAS_VISITED_RANDOM_POSE = booleanPreferencesKey("is_first_visit_random_pose")
         private val HAS_SHOWN_INFO_TOOLTIP = booleanPreferencesKey("is_first_expand_bottom_sheet")
+        private val HAS_SHOWN_QR_INFO_TOOLTIP = booleanPreferencesKey("has_shown_qr_info_tooltip")
     }
 }

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/UserRepositoryImpl.kt
@@ -67,6 +67,6 @@ class UserRepositoryImpl @Inject constructor(
     companion object {
         private val HAS_VISITED_RANDOM_POSE = booleanPreferencesKey("is_first_visit_random_pose")
         private val HAS_SHOWN_INFO_TOOLTIP = booleanPreferencesKey("is_first_expand_bottom_sheet")
-        private val HAS_SHOWN_QR_INFO_TOOLTIP = booleanPreferencesKey("has_shown_qr_info_tooltip")
+        private val HAS_SHOWN_QR_INFO_TOOLTIP = booleanPreferencesKey("is_first_visit_archive")
     }
 }

--- a/core/designsystem/src/main/java/com/neki/android/core/designsystem/button/NekiTextButton.kt
+++ b/core/designsystem/src/main/java/com/neki/android/core/designsystem/button/NekiTextButton.kt
@@ -7,7 +7,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import com.neki.android.core.designsystem.ComponentPreview
 import com.neki.android.core.designsystem.modifier.MultipleEventsCutter
 import com.neki.android.core.designsystem.modifier.get

--- a/core/designsystem/src/main/java/com/neki/android/core/designsystem/button/NekiTextButton.kt
+++ b/core/designsystem/src/main/java/com/neki/android/core/designsystem/button/NekiTextButton.kt
@@ -19,8 +19,6 @@ fun NekiTextButton(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     multipleEventsCutterEnabled: Boolean = true,
-    enabledTextColor: Color = NekiTheme.colorScheme.primary500,
-    disabledTextColor: Color = NekiTheme.colorScheme.gray200,
     contentPadding: PaddingValues = ButtonDefaults.TextButtonContentPadding,
     content: @Composable () -> Unit = {},
 ) {
@@ -36,10 +34,6 @@ fun NekiTextButton(
         modifier = modifier,
         contentPadding = contentPadding,
         enabled = enabled,
-        colors = ButtonDefaults.textButtonColors(
-            contentColor = enabledTextColor,
-            disabledContentColor = disabledTextColor,
-        ),
     ) {
         content()
     }
@@ -54,6 +48,7 @@ private fun NekiTextButtonPreview() {
         ) {
             Text(
                 text = "텍스트버튼",
+                color = NekiTheme.colorScheme.primary500,
             )
         }
     }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainContract.kt
@@ -10,7 +10,7 @@ import kotlinx.collections.immutable.persistentListOf
 
 data class ArchiveMainState(
     val isLoading: Boolean = false,
-    val isFirstEntered: Boolean = true,
+    val isFirstEntered: Boolean = false,
     val favoriteAlbum: AlbumPreview = AlbumPreview(title = "즐겨찾는사진"),
     val albums: ImmutableList<AlbumPreview> = persistentListOf(),
     val recentPhotos: ImmutableList<Photo> = persistentListOf(),

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/component/ArchiveMainTitleRow.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/component/ArchiveMainTitleRow.kt
@@ -36,7 +36,7 @@ internal fun ArchiveMainTitleRow(
             color = NekiTheme.colorScheme.gray900,
         )
         NekiTextButton(
-            contentPadding = PaddingValues(vertical = 10.dp),
+            contentPadding = PaddingValues(start = 12.dp, top = 4.dp, bottom = 4.dp),
             onClick = onClickShowAllAlbum,
         ) {
             Row(

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailScreen.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailScreen.kt
@@ -3,7 +3,6 @@ package com.neki.android.feature.pose.impl.detail
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -11,7 +10,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.neki.android.core.designsystem.DevicePreview
@@ -76,11 +74,6 @@ internal fun PoseDetailScreen(
                 .weight(1f),
             contentScale = ContentScale.Fit,
             alignment = Alignment.Center,
-        )
-        HorizontalDivider(
-            modifier = Modifier.fillMaxWidth(),
-            thickness = 1.dp,
-            color = NekiTheme.colorScheme.gray75,
         )
         PoseActionBar(
             isBookmarked = uiState.pose.isBookmarked,


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #128

## 📙 작업 설명
- QR 스캔 안내 툴팁이 최초 1회만 노출되도록 DataStore 기반 플래그 추가
- ArchiveMain isFirstEntered 기본값 false로 변경
- ArchiveMainTitleRow 버튼 패딩 조정
- NekiTextButton에서 불필요한 color 파라미터 제거
- PoseDetailScreen HorizontalDivider 제거 및 TODO 주석 추가
- 사용하지 않는 import 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * QR 정보 툴팁의 표시 상태 추적 및 표시 여부 저장 기능이 추가되었습니다.
  * 툴팁 닫기 시 표시 상태가 기록되도록 동작이 연결되었습니다.

* **스타일**
  * 텍스트 버튼의 색상 설정이 간소화되었습니다.
  * 아카이브 화면의 버튼 패딩이 조정되었습니다.
  * 자세 상세 화면에서 하단 구분선이 제거되었습니다.

* **버그 수정**
  * 아카이브 화면의 초기 진입 상태 처리 로직이 개선되어 첫 진입 판별이 안정화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->