### PR TITLE
[refactor] #107 onFailure 블록 람다 변수명 e로 통일

### DIFF
--- a/app/src/main/java/com/neki/android/app/main/MainViewModel.kt
+++ b/app/src/main/java/com/neki/android/app/main/MainViewModel.kt
@@ -105,8 +105,8 @@ class MainViewModel @Inject constructor(
                     reduce { copy(isLoading = false, scannedImageUrl = null) }
                     postSideEffect(MainSideEffect.ShowToast("이미지를 추가했어요"))
                 }
-                .onFailure { error ->
-                    Timber.e(error)
+                .onFailure { e ->
+                    Timber.e(e)
                     reduce { copy(isLoading = false) }
                     postSideEffect(MainSideEffect.ShowToast("이미지 업로드에 실패했어요"))
                 }
@@ -126,8 +126,8 @@ class MainViewModel @Inject constructor(
                     reduce { copy(isLoading = false, selectedUris = persistentListOf()) }
                     postSideEffect(MainSideEffect.ShowToast("이미지를 추가했어요"))
                 }
-                .onFailure { error ->
-                    Timber.e(error)
+                .onFailure { e ->
+                    Timber.e(e)
                     reduce { copy(isLoading = false) }
                     postSideEffect(MainSideEffect.ShowToast("이미지 업로드에 실패했어요"))
                 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumViewModel.kt
@@ -98,8 +98,8 @@ class AllAlbumViewModel @Inject constructor(
             .onSuccess { data ->
                 reduce { copy(favoriteAlbum = data) }
             }
-            .onFailure { error ->
-                Timber.e(error)
+            .onFailure { e ->
+                Timber.e(e)
             }
     }
 
@@ -108,8 +108,8 @@ class AllAlbumViewModel @Inject constructor(
             .onSuccess { data ->
                 reduce { copy(albums = data.toImmutableList()) }
             }
-            .onFailure { error ->
-                Timber.e(error)
+            .onFailure { e ->
+                Timber.e(e)
             }
     }
 
@@ -179,9 +179,9 @@ class AllAlbumViewModel @Inject constructor(
                     fetchFolders(reduce)
                     postSideEffect(AllAlbumSideEffect.ShowToastMessage("새로운 앨범을 추가했어요"))
                 }
-                .onFailure { error ->
+                .onFailure { e ->
                     postSideEffect(AllAlbumSideEffect.ShowToastMessage("앨범 추가에 실패했어요"))
-                    Timber.e(error)
+                    Timber.e(e)
                 }
             reduce { copy(isShowAddAlbumBottomSheet = false, albumNameTextState = TextFieldState()) }
         }
@@ -201,8 +201,8 @@ class AllAlbumViewModel @Inject constructor(
                     fetchFolders(reduce)
                     postSideEffect(AllAlbumSideEffect.ShowToastMessage("앨범을 삭제했어요"))
                 }
-                .onFailure { error ->
-                    Timber.e(error, "사진 삭제 실패")
+                .onFailure { e ->
+                    Timber.e(e, "사진 삭제 실패")
                     postSideEffect(AllAlbumSideEffect.ShowToastMessage("앨범 삭제에 실패했어요"))
                 }
             reduce {

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailScreen.kt
@@ -88,8 +88,9 @@ internal fun AlbumDetailRoute(
                     .onSuccess {
                         nekiToast.showToast(text = "사진을 갤러리에 다운로드했어요")
                     }
-                    .onFailure {
+                    .onFailure { e ->
                         nekiToast.showToast(text = "다운로드에 실패했어요")
+                        Timber.e(e)
                     }
             }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailViewModel.kt
@@ -204,8 +204,8 @@ class AlbumDetailViewModel @AssistedInject constructor(
                 reduce { copy(isLoading = false) }
                 postSideEffect(AlbumDetailSideEffect.RefreshPhotos)
                 postSideEffect(AlbumDetailSideEffect.ShowToastMessage("새로운 사진을 추가했어요"))
-            }.onFailure { error ->
-                Timber.e(error)
+            }.onFailure { e ->
+                Timber.e(e)
                 postSideEffect(AlbumDetailSideEffect.ShowToastMessage("이미지 업로드에 실패했어요"))
                 reduce { copy(isLoading = false) }
             }
@@ -306,8 +306,8 @@ class AlbumDetailViewModel @AssistedInject constructor(
                     }
                     postSideEffect(AlbumDetailSideEffect.ShowToastMessage("사진을 삭제했어요"))
                 }
-                .onFailure { error ->
-                    Timber.e(error)
+                .onFailure { e ->
+                    Timber.e(e)
                     reduce {
                         copy(
                             isShowDeleteDialog = false,
@@ -348,8 +348,8 @@ class AlbumDetailViewModel @AssistedInject constructor(
                     }
                     postSideEffect(AlbumDetailSideEffect.ShowToastMessage("사진을 삭제했어요"))
                 }
-                .onFailure { error ->
-                    Timber.e(error)
+                .onFailure { e ->
+                    Timber.e(e)
                     reduce {
                         copy(
                             isShowDeleteBottomSheet = false,

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
@@ -129,8 +129,8 @@ class ArchiveMainViewModel @Inject constructor(
             .onSuccess { data ->
                 reduce { copy(favoriteAlbum = data) }
             }
-            .onFailure { error ->
-                Timber.e(error)
+            .onFailure { e ->
+                Timber.e(e)
             }
     }
 
@@ -139,8 +139,8 @@ class ArchiveMainViewModel @Inject constructor(
             .onSuccess { data ->
                 reduce { copy(recentPhotos = data.toImmutableList()) }
             }
-            .onFailure { error ->
-                Timber.e(error)
+            .onFailure { e ->
+                Timber.e(e)
             }
     }
 
@@ -149,8 +149,8 @@ class ArchiveMainViewModel @Inject constructor(
             .onSuccess { data ->
                 reduce { copy(albums = data.toImmutableList()) }
             }
-            .onFailure { error ->
-                Timber.e(error)
+            .onFailure { e ->
+                Timber.e(e)
             }
     }
 
@@ -195,8 +195,8 @@ class ArchiveMainViewModel @Inject constructor(
             ).onSuccess {
                 fetchPhotos(reduce, 1) // 가장 최신 데이터 가져오기
                 onSuccess()
-            }.onFailure { error ->
-                Timber.e(error)
+            }.onFailure { e ->
+                Timber.e(e)
                 postSideEffect(ArchiveMainSideEffect.ShowToastMessage("이미지 업로드에 실패했어요"))
                 reduce { copy(isLoading = false) }
             }
@@ -217,8 +217,8 @@ class ArchiveMainViewModel @Inject constructor(
             ).onSuccess {
                 fetchPhotos(reduce)
                 onSuccess()
-            }.onFailure { error ->
-                Timber.e(error)
+            }.onFailure { e ->
+                Timber.e(e)
                 postSideEffect(ArchiveMainSideEffect.ShowToastMessage("이미지 업로드에 실패했어요"))
                 reduce { copy(isLoading = false) }
             }
@@ -236,9 +236,9 @@ class ArchiveMainViewModel @Inject constructor(
                     fetchFolders(reduce)
                     postSideEffect(ArchiveMainSideEffect.ShowToastMessage("새로운 앨범을 추가했어요"))
                 }
-                .onFailure { error ->
+                .onFailure { e ->
                     postSideEffect(ArchiveMainSideEffect.ShowToastMessage("앨범 추가에 실패했어요"))
-                    Timber.e(error)
+                    Timber.e(e)
                 }
             reduce { copy(isShowAddAlbumBottomSheet = false, albumNameTextState = TextFieldState()) }
         }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoScreen.kt
@@ -56,6 +56,7 @@ import com.neki.android.feature.archive.impl.util.ImageDownloader
 import kotlinx.coroutines.flow.dropWhile
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @Composable
 internal fun AllPhotoRoute(
@@ -90,8 +91,9 @@ internal fun AllPhotoRoute(
                     .onSuccess {
                         nekiToast.showToast(text = "사진을 갤러리에 다운로드했어요")
                     }
-                    .onFailure {
+                    .onFailure { e ->
                         nekiToast.showToast(text = "다운로드에 실패했어요")
+                        Timber.e(e)
                     }
             }
         }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoViewModel.kt
@@ -223,8 +223,8 @@ class AllPhotoViewModel @Inject constructor(
                     }
                     postSideEffect(AllPhotoSideEffect.ShowToastMessage("사진을 삭제했어요"))
                 }
-                .onFailure { error ->
-                    Timber.e(error)
+                .onFailure { e ->
+                    Timber.e(e)
                     reduce { copy(isLoading = false) }
                     postSideEffect(AllPhotoSideEffect.ShowToastMessage("사진 삭제에 실패했어요"))
                 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -18,6 +18,7 @@ import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.model.Photo
 import com.neki.android.core.navigation.result.LocalResultEventBus
 import com.neki.android.core.ui.component.LoadingDialog
+import timber.log.Timber
 import com.neki.android.core.ui.compose.collectWithLifecycle
 import com.neki.android.core.ui.toast.NekiToast
 import com.neki.android.feature.archive.impl.component.DeletePhotoDialog
@@ -44,8 +45,9 @@ internal fun PhotoDetailRoute(
                     .onSuccess {
                         nekiToast.showToast(text = "사진을 갤러리에 다운로드했어요")
                     }
-                    .onFailure {
+                    .onFailure { e ->
                         nekiToast.showToast(text = "다운로드에 실패했어요")
+                        Timber.e(e)
                     }
             }
         }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
@@ -46,8 +46,8 @@ class PhotoDetailViewModel @AssistedInject constructor(
                                 Timber.d("updateFavorite success")
                                 store.onIntent(PhotoDetailIntent.FavoriteCommitted(newFavorite))
                             }
-                            .onFailure { error ->
-                                Timber.e(error, "updateFavorite failed")
+                            .onFailure { e ->
+                                Timber.e(e, "updateFavorite failed")
                                 store.onIntent(PhotoDetailIntent.RevertFavorite(committedFavorite))
                             }
                     }
@@ -114,8 +114,8 @@ class PhotoDetailViewModel @AssistedInject constructor(
                     postSideEffect(PhotoDetailSideEffect.ShowToastMessage("사진을 삭제했어요"))
                     postSideEffect(PhotoDetailSideEffect.NavigateBack)
                 }
-                .onFailure { error ->
-                    Timber.e(error)
+                .onFailure { e ->
+                    Timber.e(e)
                     reduce { copy(isLoading = false) }
                     postSideEffect(PhotoDetailSideEffect.ShowToastMessage("사진 삭제에 실패했어요"))
                 }

--- a/feature/auth/impl/src/main/kotlin/com/neki/android/feature/auth/impl/login/LoginViewModel.kt
+++ b/feature/auth/impl/src/main/kotlin/com/neki/android/feature/auth/impl/login/LoginViewModel.kt
@@ -51,8 +51,8 @@ class LoginViewModel @Inject constructor(
                 )
                 checkTermAgreementState(postSideEffect)
             }
-            .onFailure { exception ->
-                Timber.e(exception)
+            .onFailure { e ->
+                Timber.e(e)
                 postSideEffect(LoginSideEffect.ShowToastMessage("가입에 실패했습니다. 다시 시도해주세요."))
             }
         reduce { copy(isLoading = false) }
@@ -70,8 +70,8 @@ class LoginViewModel @Inject constructor(
                     postSideEffect(LoginSideEffect.NavigateToTerm)
                 }
             }
-            .onFailure { exception ->
-                Timber.e(exception)
+            .onFailure { e ->
+                Timber.e(e)
                 postSideEffect(LoginSideEffect.NavigateToTerm)
             }
     }

--- a/feature/auth/impl/src/main/kotlin/com/neki/android/feature/auth/impl/splash/SplashViewModel.kt
+++ b/feature/auth/impl/src/main/kotlin/com/neki/android/feature/auth/impl/splash/SplashViewModel.kt
@@ -70,8 +70,8 @@ class SplashViewModel @Inject constructor(
                         }
                     }
                 }
-                .onFailure { exception ->
-                    Timber.e(exception, "Failed to fetch app version")
+                .onFailure { e ->
+                    Timber.e(e, "Failed to fetch app version")
                     fetchAuthState(postSideEffect)
                 }
         }
@@ -102,8 +102,8 @@ class SplashViewModel @Inject constructor(
                 ).onSuccess {
                     tokenRepository.saveTokens(it.accessToken, it.refreshToken)
                     postSideEffect(SplashSideEffect.NavigateToMain)
-                }.onFailure { exception ->
-                    Timber.e(exception)
+                }.onFailure { e ->
+                    Timber.e(e)
                     postSideEffect(SplashSideEffect.NavigateToLogin)
                 }
             } else {

--- a/feature/auth/impl/src/main/kotlin/com/neki/android/feature/auth/impl/term/TermViewModel.kt
+++ b/feature/auth/impl/src/main/kotlin/com/neki/android/feature/auth/impl/term/TermViewModel.kt
@@ -72,8 +72,8 @@ class TermViewModel @Inject constructor(
                 .onSuccess { terms ->
                     reduce { copy(isLoading = false, terms = terms.toImmutableList()) }
                 }
-                .onFailure { error ->
-                    Timber.e(error)
+                .onFailure { e ->
+                    Timber.e(e)
                     reduce { copy(isLoading = false) }
                 }
         }
@@ -91,8 +91,8 @@ class TermViewModel @Inject constructor(
                 authRepository.setCompletedOnboarding(true)
                 postSideEffect(TermSideEffect.NavigateToMain)
             }
-            .onFailure { exception ->
-                Timber.e(exception)
+            .onFailure { e ->
+                Timber.e(e)
                 postSideEffect(TermSideEffect.ShowToastMessage("약관 동의에 실패했습니다. 다시 시도해주세요."))
             }
         reduce { copy(isLoading = false) }

--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import javax.inject.Inject
 
 @HiltViewModel
@@ -113,7 +114,8 @@ class MapViewModel @Inject constructor(
                     reduce { copy(isCameraOnCurrentLocation = true, isVisibleRefreshButton = false) }
                     postSideEffect(MapEffect.MoveCameraToPosition(location, isRequiredLoadPhotoBooths = true))
                 }
-                .onFailure {
+                .onFailure { e ->
+                    Timber.e(e)
                     // 위치 조회 실패 시 강남역으로 카메라 이동
                     postSideEffect(
                         MapEffect.MoveCameraToPosition(
@@ -286,7 +288,8 @@ class MapViewModel @Inject constructor(
                     reduce { copy(isLoading = false, brands = loadedBrands.toImmutableList()) }
                     cacheBrandImages(loadedBrands, reduce)
                 }
-                .onFailure {
+                .onFailure { e ->
+                    Timber.e(e)
                     reduce { copy(isLoading = false) }
                 }
         }
@@ -388,7 +391,8 @@ class MapViewModel @Inject constructor(
                         }.toImmutableList(),
                     )
                 }
-            }.onFailure {
+            }.onFailure { e ->
+                Timber.e(e)
                 reduce { copy(isLoading = false) }
                 postSideEffect(MapEffect.ShowToastMessage("포토부스 조회에 실패했습니다."))
             }

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/main/MyPageViewModel.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/main/MyPageViewModel.kt
@@ -120,8 +120,8 @@ internal class MyPageViewModel @Inject constructor(
                     )
                 }
             }
-            .onFailure {
-                Timber.e(it)
+            .onFailure { e ->
+                Timber.e(e)
                 reduce { copy(isLoading = false) }
             }
     }
@@ -165,8 +165,8 @@ internal class MyPageViewModel @Inject constructor(
                     postSideEffect(MyPageEffect.NavigateBack)
                 }
             }
-            .onFailure {
-                Timber.e(it)
+            .onFailure { e ->
+                Timber.e(e)
                 reduce {
                     copy(
                         isLoading = false,
@@ -194,8 +194,8 @@ internal class MyPageViewModel @Inject constructor(
                 reduce { copy(isLoading = false) }
                 postSideEffect(MyPageEffect.UnlinkWithKakao)
             }
-            .onFailure {
-                Timber.e(it)
+            .onFailure { e ->
+                Timber.e(e)
                 reduce { copy(isLoading = false) }
             }
     }

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/album/UploadAlbumViewModel.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/album/UploadAlbumViewModel.kt
@@ -90,8 +90,8 @@ class UploadAlbumViewModel @AssistedInject constructor(
             .onSuccess { data ->
                 reduce { copy(favoriteAlbum = data) }
             }
-            .onFailure { error ->
-                Timber.e(error)
+            .onFailure { e ->
+                Timber.e(e)
             }
     }
 
@@ -100,8 +100,8 @@ class UploadAlbumViewModel @AssistedInject constructor(
             .onSuccess { data ->
                 reduce { copy(albums = data.toImmutableList()) }
             }
-            .onFailure { error ->
-                Timber.e(error)
+            .onFailure { e ->
+                Timber.e(e)
             }
     }
 
@@ -157,8 +157,8 @@ class UploadAlbumViewModel @AssistedInject constructor(
             ).onSuccess { data ->
                 Timber.d(data.toString())
                 onSuccessAction()
-            }.onFailure { error ->
-                onFailureAction(error)
+            }.onFailure { e ->
+                onFailureAction(e)
             }
         }
     }
@@ -178,8 +178,8 @@ class UploadAlbumViewModel @AssistedInject constructor(
                 folderId = albumId,
             ).onSuccess {
                 onSuccessAction()
-            }.onFailure { error ->
-                onFailureAction(error)
+            }.onFailure { e ->
+                onFailureAction(e)
             }
         }
     }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailViewModel.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailViewModel.kt
@@ -51,8 +51,8 @@ class PoseDetailViewModel @AssistedInject constructor(
                                 Timber.d("updateBookmark success")
                                 store.onIntent(PoseDetailIntent.BookmarkCommitted(newBookmark))
                             }
-                            .onFailure { error ->
-                                Timber.e(error, "updateBookmark failed")
+                            .onFailure { e ->
+                                Timber.e(e, "updateBookmark failed")
                                 store.onIntent(PoseDetailIntent.RevertBookmark(committedBookmark))
                             }
                     }
@@ -93,8 +93,8 @@ class PoseDetailViewModel @AssistedInject constructor(
                 .onSuccess { data ->
                     reduce { copy(pose = data, committedBookmark = data.isBookmarked) }
                 }
-                .onFailure { error ->
-                    Timber.e(error)
+                .onFailure { e ->
+                    Timber.e(e)
                 }
         }
     }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseViewModel.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseViewModel.kt
@@ -108,8 +108,8 @@ internal class RandomPoseViewModel @AssistedInject constructor(
                         copy(committedBookmarks = committedBookmarks + (poseId to newBookmarkStatus))
                     }
                 }
-                .onFailure { error ->
-                    Timber.e(error, "updateBookmark failed for poseId: $poseId")
+                .onFailure { e ->
+                    Timber.e(e, "updateBookmark failed for poseId: $poseId")
                     reduce {
                         copy(
                             poseList = poseList.map { pose ->
@@ -167,11 +167,11 @@ internal class RandomPoseViewModel @AssistedInject constructor(
                             committedBookmarks = committedBookmarks + (pose.id to pose.isBookmarked),
                         )
                     }
-                }.onFailure { error ->
-                    if (error is NoMorePoseException && error.code == NO_MORE_RANDOM_POSE) {
+                }.onFailure { e ->
+                    if (e is NoMorePoseException && e.code == NO_MORE_RANDOM_POSE) {
                         reduce { copy(hasNewPose = false) }
                         postSideEffect(RandomPoseEffect.ShowToast("모든 포즈를 불러왔어요"))
-                    } else Timber.e(error)
+                    } else Timber.e(e)
                 }
             }
         }
@@ -222,10 +222,10 @@ internal class RandomPoseViewModel @AssistedInject constructor(
                         currentIndex = 0,
                     )
                 }
-            }.onFailure { error ->
+            }.onFailure { e ->
                 reduce { copy(isLoading = false) }
                 postSideEffect(RandomPoseEffect.ShowToast("포즈를 불러오는데 실패했어요"))
-                Timber.e(error)
+                Timber.e(e)
             }
         }
     }


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #107

## 📙 작업 설명
- `onFailure` 블록의 람다 변수명이 `error`, `exception`, `it`(implicit) 등으로 제각각이었던 것을 **모든** `onFailure` 블록에서 `e ->`로 통일
- `e`를 선언만 하고 사용하지 않던 블록에 `Timber.e(e)` 로깅 추가
- 총 17개 파일, 43개 `onFailure` 블록 변경

### 변경 카테고리
| 기존 패턴 | 변경 수 |
|---|---|
| `{ error ->` → `{ e ->` | 27개 |
| `{ exception ->` → `{ e ->` | 5개 |
| implicit `it` → `{ e ->` | 3개 |
| 미사용 파라미터에 `{ e ->` + `Timber.e(e)` 추가 | 8개 |