### PR TITLE
[fix] #103 RepositoryImpl의 불필요한 .data 구문 제거

### DIFF
--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/FolderRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/FolderRepositoryImpl.kt
@@ -20,27 +20,27 @@ class FolderRepositoryImpl @Inject constructor(
     override suspend fun createFolder(name: String): Result<Unit> = runSuspendCatching {
         folderService.createFolder(
             requestBody = CreateFolderRequest(name = name),
-        ).data
+        )
     }
 
     override suspend fun deleteFolder(id: List<Long>, deletePhotos: Boolean): Result<Unit> = runSuspendCatching {
         folderService.deleteFolder(
             requestBody = DeleteFolderRequest(folderIds = id),
             deletePhotos = deletePhotos,
-        ).data
+        )
     }
 
     override suspend fun removePhotosFromFolder(folderId: Long, photoIds: List<Long>): Result<Unit> = runSuspendCatching {
         folderService.removePhotosFromFolder(
             folderId = folderId,
             requestBody = DeletePhotoRequest(photoIds = photoIds),
-        ).data
+        )
     }
 
     override suspend fun updateFolder(folderId: Long, name: String): Result<Unit> = runSuspendCatching {
         folderService.updateFolder(
             folderId = folderId,
             requestBody = UpdateFolderRequest(name = name),
-        ).data
+        )
     }
 }

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/PhotoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/PhotoRepositoryImpl.kt
@@ -45,23 +45,23 @@ class PhotoRepositoryImpl @Inject constructor(
                 uploads = mediaIds.map { RegisterPhotoRequest.Upload(mediaId = it) },
                 favorite = favorite,
             ),
-        ).data
+        )
     }
 
     override suspend fun deletePhoto(photoId: Long): Result<Unit> = runSuspendCatching {
         photoService.deletePhoto(
             requestBody = DeletePhotoRequest(photoIds = listOf(photoId)),
-        ).data
+        )
     }
 
     override suspend fun deletePhoto(photoIds: List<Long>): Result<Unit> = runSuspendCatching {
         photoService.deletePhoto(
             requestBody = DeletePhotoRequest(photoIds = photoIds),
-        ).data
+        )
     }
 
     override suspend fun updateFavorite(photoId: Long, favorite: Boolean): Result<Unit> = runSuspendCatching {
-        photoService.updateFavorite(photoId, favorite).data
+        photoService.updateFavorite(photoId, favorite)
     }
 
     override suspend fun getFavoritePhotos(

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/TermRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/TermRepositoryImpl.kt
@@ -20,6 +20,6 @@ class TermRepositoryImpl @Inject constructor(
                 TermAgreementsRequest.Agreement(termId = termId, agreed = true)
             },
         )
-        termService.agreeTerms(request).data
+        termService.agreeTerms(request)
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #103 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- `BasicNullableResponse` 타입의 API를 호출하는 RepositoryImpl의 불필요한 `.data` 구문 제거
- 총 3개 파일, `.data`를 반환하고 있던 오버라이딩 함수 9개



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **리팩토링**
  * 여러 저장소의 API 응답 처리 로직을 개선했습니다. 폴더, 사진, 약관 관련 기능에서 데이터 추출 방식을 최적화하여 코드 일관성을 강화하고 유지보수성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->