### PR TITLE
[feat] #147 QR 지원 브랜드 추가

### DIFF
--- a/feature/photo-upload/impl/build.gradle.kts
+++ b/feature/photo-upload/impl/build.gradle.kts
@@ -41,6 +41,10 @@ android {
         buildConfigField("String", "PHOTO_GRAY_URL", properties["PHOTO_GRAY_URL"].toString())
         buildConfigField("String", "PHOTO_GRAY_IMAGE_URL", properties["PHOTO_GRAY_IMAGE_URL"].toString())
         buildConfigField("String", "PHOTO_GRAY_IMAGE_URL_MIME_TYPE", properties["PHOTO_GRAY_IMAGE_URL_MIME_TYPE"].toString())
+
+        buildConfigField("String", "MONO_MANSION_URL", properties["MONO_MANSION_URL"].toString())
+        buildConfigField("String", "MONO_MANSION_IMAGE_URL", properties["MONO_MANSION_IMAGE_URL"].toString())
+        buildConfigField("String", "MONO_MANSION_IMAGE_URL_MIME_TYPE", properties["MONO_MANSION_IMAGE_URL_MIME_TYPE"].toString())
     }
 }
 

--- a/feature/photo-upload/impl/build.gradle.kts
+++ b/feature/photo-upload/impl/build.gradle.kts
@@ -29,6 +29,18 @@ android {
         buildConfigField("String", "LIFE_FOUR_CUT_URL", properties["LIFE_FOUR_CUT_URL"].toString())
         buildConfigField("String", "LIFE_FOUR_CUT_IMAGE_URL", properties["LIFE_FOUR_CUT_IMAGE_URL"].toString())
         buildConfigField("String", "LIFE_FOUR_CUT_IMAGE_URL_MIME_TYPE", properties["LIFE_FOUR_CUT_IMAGE_URL_MIME_TYPE"].toString())
+
+        buildConfigField("String", "PHOTO_SIGNATURE_URL", properties["PHOTO_SIGNATURE_URL"].toString())
+        buildConfigField("String", "PHOTO_SIGNATURE_IMAGE_URL", properties["PHOTO_SIGNATURE_IMAGE_URL"].toString())
+        buildConfigField("String", "PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE", properties["PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE"].toString())
+
+        buildConfigField("String", "HARU_FILM_URL", properties["HARU_FILM_URL"].toString())
+        buildConfigField("String", "HARU_FILM_IMAGE_URL", properties["HARU_FILM_IMAGE_URL"].toString())
+        buildConfigField("String", "HARU_FILM_IMAGE_URL_MIME_TYPE", properties["HARU_FILM_IMAGE_URL_MIME_TYPE"].toString())
+
+        buildConfigField("String", "PHOTO_GRAY_URL", properties["PHOTO_GRAY_URL"].toString())
+        buildConfigField("String", "PHOTO_GRAY_IMAGE_URL", properties["PHOTO_GRAY_IMAGE_URL"].toString())
+        buildConfigField("String", "PHOTO_GRAY_IMAGE_URL_MIME_TYPE", properties["PHOTO_GRAY_IMAGE_URL_MIME_TYPE"].toString())
     }
 }
 

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
@@ -113,10 +113,11 @@ internal class QRScanViewModel @Inject constructor() : ViewModel() {
             url.contains(BuildConfig.LIFE_FOUR_CUT_URL) ||
             url.contains(BuildConfig.PHOTO_SIGNATURE_URL) ||
             url.contains(BuildConfig.HARU_FILM_URL) ||
-            url.contains(BuildConfig.PHOTO_GRAY_URL)
+            url.contains(BuildConfig.PHOTO_GRAY_URL) ||
+            url.contains(BuildConfig.MONO_MANSION_URL)
     }
 
     private fun isShouldFirstDownloadBrand(url: String): Boolean {
-        return false
+        return url.contains(BuildConfig.MONO_MANSION_URL)
     }
 }

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
@@ -110,7 +110,10 @@ internal class QRScanViewModel @Inject constructor() : ViewModel() {
 
     private fun isSupportedBrand(url: String): Boolean {
         return url.startsWith(BuildConfig.PHOTOISM_URL) ||
-            url.startsWith(BuildConfig.LIFE_FOUR_CUT_URL)
+            url.startsWith(BuildConfig.LIFE_FOUR_CUT_URL) ||
+            url.startsWith(BuildConfig.PHOTO_SIGNATURE_URL) ||
+            url.startsWith(BuildConfig.HARU_FILM_URL) ||
+            url.startsWith(BuildConfig.PHOTO_GRAY_URL)
     }
 
     private fun isShouldFirstDownloadBrand(url: String): Boolean {

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
@@ -109,11 +109,11 @@ internal class QRScanViewModel @Inject constructor() : ViewModel() {
     }
 
     private fun isSupportedBrand(url: String): Boolean {
-        return url.startsWith(BuildConfig.PHOTOISM_URL) ||
-            url.startsWith(BuildConfig.LIFE_FOUR_CUT_URL) ||
-            url.startsWith(BuildConfig.PHOTO_SIGNATURE_URL) ||
-            url.startsWith(BuildConfig.HARU_FILM_URL) ||
-            url.startsWith(BuildConfig.PHOTO_GRAY_URL)
+        return url.contains(BuildConfig.PHOTOISM_URL) ||
+            url.contains(BuildConfig.LIFE_FOUR_CUT_URL) ||
+            url.contains(BuildConfig.PHOTO_SIGNATURE_URL) ||
+            url.contains(BuildConfig.HARU_FILM_URL) ||
+            url.contains(BuildConfig.PHOTO_GRAY_URL)
     }
 
     private fun isShouldFirstDownloadBrand(url: String): Boolean {

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/util/PhotoWebViewClient.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/util/PhotoWebViewClient.kt
@@ -20,31 +20,31 @@ class PhotoWebViewClient(
 
         when {
             // 포토이즘
-            url.startsWith(BuildConfig.PHOTOISM_IMAGE_URL) && url.endsWith(BuildConfig.PHOTOISM_IMAGE_URL_MIME_TYPE) -> {
+            url.contains(BuildConfig.PHOTOISM_IMAGE_URL) && url.endsWith(BuildConfig.PHOTOISM_IMAGE_URL_MIME_TYPE) -> {
                 Timber.d("포토이즘 이미지")
                 onImageUrlDetected(url)
             }
 
             // 인생네컷
-            url.startsWith(BuildConfig.LIFE_FOUR_CUT_IMAGE_URL) && url.endsWith(BuildConfig.LIFE_FOUR_CUT_IMAGE_URL_MIME_TYPE) -> {
+            url.contains(BuildConfig.LIFE_FOUR_CUT_IMAGE_URL) && url.endsWith(BuildConfig.LIFE_FOUR_CUT_IMAGE_URL_MIME_TYPE) -> {
                 Timber.d("인생네컷 이미지")
                 onImageUrlDetected(url)
             }
 
             // 포토시그니처
-            url.startsWith(BuildConfig.PHOTO_SIGNATURE_IMAGE_URL) && url.endsWith(BuildConfig.PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE) -> {
+            url.contains(BuildConfig.PHOTO_SIGNATURE_IMAGE_URL) && url.endsWith(BuildConfig.PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE) -> {
                 Timber.d("포토시그니처 이미지")
                 onImageUrlDetected(url)
             }
 
             // 하루필름
-            url.startsWith(BuildConfig.HARU_FILM_IMAGE_URL) && url.endsWith(BuildConfig.HARU_FILM_IMAGE_URL_MIME_TYPE) -> {
+            url.contains(BuildConfig.HARU_FILM_IMAGE_URL) && url.endsWith(BuildConfig.HARU_FILM_IMAGE_URL_MIME_TYPE) -> {
                 Timber.d("하루필름 이미지")
                 onImageUrlDetected(url)
             }
 
             // 포토그레이
-            url.startsWith(BuildConfig.PHOTO_GRAY_IMAGE_URL) && url.endsWith(BuildConfig.PHOTO_GRAY_IMAGE_URL_MIME_TYPE) -> {
+            url.contains(BuildConfig.PHOTO_GRAY_IMAGE_URL) && url.endsWith(BuildConfig.PHOTO_GRAY_IMAGE_URL_MIME_TYPE) -> {
                 Timber.d("포토그레이 이미지")
                 onImageUrlDetected(url)
             }

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/util/PhotoWebViewClient.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/util/PhotoWebViewClient.kt
@@ -30,6 +30,24 @@ class PhotoWebViewClient(
                 Timber.d("인생네컷 이미지")
                 onImageUrlDetected(url)
             }
+
+            // 포토시그니처
+            url.startsWith(BuildConfig.PHOTO_SIGNATURE_IMAGE_URL) && url.endsWith(BuildConfig.PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE) -> {
+                Timber.d("포토시그니처 이미지")
+                onImageUrlDetected(url)
+            }
+
+            // 하루필름
+            url.startsWith(BuildConfig.HARU_FILM_IMAGE_URL) && url.endsWith(BuildConfig.HARU_FILM_IMAGE_URL_MIME_TYPE) -> {
+                Timber.d("하루필름 이미지")
+                onImageUrlDetected(url)
+            }
+
+            // 포토그레이
+            url.startsWith(BuildConfig.PHOTO_GRAY_IMAGE_URL) && url.endsWith(BuildConfig.PHOTO_GRAY_IMAGE_URL_MIME_TYPE) -> {
+                Timber.d("포토그레이 이미지")
+                onImageUrlDetected(url)
+            }
         }
 
         return super.shouldInterceptRequest(view, request)

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/util/PhotoWebViewClient.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/util/PhotoWebViewClient.kt
@@ -48,6 +48,12 @@ class PhotoWebViewClient(
                 Timber.d("포토그레이 이미지")
                 onImageUrlDetected(url)
             }
+
+            // 모노맨션
+            url.contains(BuildConfig.MONO_MANSION_IMAGE_URL) && url.endsWith(BuildConfig.MONO_MANSION_IMAGE_URL_MIME_TYPE) -> {
+                Timber.d("모노맨션 이미지")
+                onImageUrlDetected(url)
+            }
         }
 
         return super.shouldInterceptRequest(view, request)


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #147 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 데모데이 대비 QR 스캔 지원 브랜드를 추가했습니다.

**추가 브랜드**
- 포토시그니처
- 하루필름
- 포토그레이
- 모노맨션

- Github Secret 및 노션 문서 업데이트했습니다.

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 현재 BuildConfig 를 사용해서 암호화해서 보관하고 있는데, 브랜드가 많아질수록 복잡해지고, 
WebClient, ViewModel 쪽에서 검사하는 로직도 복잡해질 것 같습니다.
- 추후 서버에 저장하는 방향으로 요청드릴 계획입니다.


<!-- Release 용 PR 본문!
## ✅ 버전명
ex) 8 (1.0.0)

## 📙 업데이트 사항 (작업 PR 및 작업 내용)
-

## 🧪 테스트 확인 사항
- [ ] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [ ] 기존 기능 영향 없음


## 💬 QA 후 업데이트 사항
-
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 포토 시그니처, 하루 필름, 포토 그레이, 모노 맨션 등 네 가지 추가 사진 서비스 지원 추가
* 각 서비스의 이미지 감지 및 처리 기능 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->