### PR TITLE
[Fix] #144 네컷지도 2차 QA 이슈 수정

### DIFF
--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapScreen.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapScreen.kt
@@ -228,6 +228,7 @@ fun MapScreen(
         MapUiSettings(
             isLocationButtonEnabled = false,
             isZoomControlEnabled = false,
+            isCompassEnabled = false,
         )
     }
 

--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
@@ -362,7 +362,7 @@ class MapViewModel @Inject constructor(
         reduce: (MapState.() -> MapState) -> Unit,
         postSideEffect: (MapEffect) -> Unit,
     ) {
-        val checkedBrandIds = state.brands.filter { it.isChecked }.map { it.id }
+        val checkedBrandNames = state.brands.filter { it.isChecked }.map { it.name }
 
         // 좌상단 -> 우상단 -> 우하단 -> 좌하단 -> 좌상단 (닫힌 다각형)
         val coordinates = listOf(
@@ -378,7 +378,7 @@ class MapViewModel @Inject constructor(
 
             mapRepository.getPhotoBoothsByPolygon(
                 coordinates = coordinates,
-                brandIds = checkedBrandIds,
+                brandIds = emptyList(),
             ).onSuccess { photoBooths ->
                 reduce {
                     copy(
@@ -388,6 +388,7 @@ class MapViewModel @Inject constructor(
                                 imageUrl = brands.find {
                                     it.name == photoBooth.brandName
                                 }?.imageUrl.orEmpty(),
+                                isCheckedBrand = checkedBrandNames.isEmpty() || photoBooth.brandName in checkedBrandNames,
                             )
                         }.toImmutableList(),
                     )


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #144 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- 브랜드 필터링된 상태에서 '이 지역 재검색' 시 전체 브랜드 대상으로 조회 후 필터링된 브랜드 노출되도록 수정
- 네이버지도 회전 시 좌측 상단 노출되는 나침판 옵션 비활성화

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| 필터링 |<video src="https://github.com/user-attachments/assets/a69b4123-0d3b-4837-a0c8-baf4ef00688a" width="300" />| 기능 설명 |<img src="링크" width="300" />|

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- `AddPhotoBottomSheet`의 추가 버튼 중앙정렬 이슈는 디자이너 문의 결과 의도한 디자인이라는 답변을 받았습니다.
https://www.figma.com/design/fEoUAq5t5VrE3EU2fhZCd8?node-id=5022-37301&m=dev#1646431756


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 지도의 나침판 UI 비활성화
  * 브랜드 필터링 로직 개선으로 포토부스 검색 결과의 정확도 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->