### PR TITLE
[feat] #149 좌우 스와이프 시 무한 스크롤 기능 추가

### DIFF
--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
@@ -6,9 +6,10 @@ import com.neki.android.feature.archive.api.ArchiveResult
 data class PhotoDetailState(
     val isLoading: Boolean = false,
     val photos: List<Photo> = emptyList(),
-    val currentIndex: Int = 0,
+    val currentPage: Int = 0,
     val isShowDeleteDialog: Boolean = false,
 ) {
+    val currentIndex get() = if (photos.isEmpty()) 0 else currentPage % photos.size
     val photo: Photo get() = photos.getOrElse(currentIndex) { Photo() }
 }
 
@@ -19,7 +20,7 @@ sealed interface PhotoDetailIntent {
     // Pager Intent
     data object ClickLeftPhoto : PhotoDetailIntent
     data object ClickRightPhoto : PhotoDetailIntent
-    data class PageChanged(val index: Int) : PhotoDetailIntent
+    data class PageChanged(val page: Int) : PhotoDetailIntent
 
     // ActionBar Intent
     data object ClickDownloadIcon : PhotoDetailIntent

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import kotlinx.coroutines.launch
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.neki.android.core.designsystem.DevicePreview
@@ -35,6 +34,7 @@ import com.neki.android.core.ui.toast.NekiToast
 import com.neki.android.feature.archive.impl.component.DeletePhotoDialog
 import com.neki.android.feature.archive.impl.photo_detail.component.PhotoDetailActionBar
 import com.neki.android.feature.archive.impl.util.ImageDownloader
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @Composable
@@ -46,7 +46,7 @@ internal fun PhotoDetailRoute(
     val context = LocalContext.current
     val nekiToast = remember { NekiToast(context) }
     val resultEventBus = LocalResultEventBus.current
-    val pagerState = rememberPagerState(initialPage = uiState.currentIndex) { uiState.photos.size }
+    val pagerState = rememberPagerState(initialPage = uiState.currentPage) { Int.MAX_VALUE }
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(pagerState) {
@@ -70,6 +70,7 @@ internal fun PhotoDetailRoute(
                         Timber.e(e)
                     }
             }
+
             is PhotoDetailSideEffect.AnimateToPage -> coroutineScope.launch {
                 pagerState.animateScrollToPage(
                     page = sideEffect.index,
@@ -90,7 +91,7 @@ internal fun PhotoDetailRoute(
 internal fun PhotoDetailScreen(
     uiState: PhotoDetailState = PhotoDetailState(),
     onIntent: (PhotoDetailIntent) -> Unit = {},
-    pagerState: PagerState = rememberPagerState { uiState.photos.size },
+    pagerState: PagerState = rememberPagerState { Int.MAX_VALUE },
 ) {
     Column(
         modifier = Modifier
@@ -107,7 +108,9 @@ internal fun PhotoDetailScreen(
                 .fillMaxWidth()
                 .weight(1f),
             state = pagerState,
-        ) { index ->
+            beyondViewportPageCount = 1,
+        ) { page ->
+            val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
             Box {
                 AsyncImage(
                     modifier = Modifier.fillMaxSize(),

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
@@ -36,7 +36,7 @@ class PhotoDetailViewModel @AssistedInject constructor(
         mviIntentStore(
             initialState = PhotoDetailState(
                 photos = key.photos,
-                currentIndex = key.initialIndex,
+                currentPage = key.initialIndex,
             ),
             onIntent = ::onIntent,
         )
@@ -79,26 +79,16 @@ class PhotoDetailViewModel @AssistedInject constructor(
 
             // Pager Intent
             PhotoDetailIntent.ClickLeftPhoto -> {
-                if (state.currentIndex > 0) {
-                    postSideEffect(PhotoDetailSideEffect.AnimateToPage(state.currentIndex - 1))
-                } else {
-                    postSideEffect(PhotoDetailSideEffect.ShowToastMessage("첫번째 사진이에요"))
+                if (state.currentPage > 0) {
+                    postSideEffect(PhotoDetailSideEffect.AnimateToPage(state.currentPage - 1))
                 }
             }
 
-            PhotoDetailIntent.ClickRightPhoto -> {
-                if (state.currentIndex < state.photos.lastIndex) {
-                    postSideEffect(PhotoDetailSideEffect.AnimateToPage(state.currentIndex + 1))
-                } else if (!hasNext) {
-                    postSideEffect(PhotoDetailSideEffect.ShowToastMessage("마지막 사진이에요"))
-                } else {
-                    postSideEffect(PhotoDetailSideEffect.ShowToastMessage("새로운 사진을 불러오고 있어요"))
-                }
-            }
+            PhotoDetailIntent.ClickRightPhoto -> postSideEffect(PhotoDetailSideEffect.AnimateToPage(state.currentPage + 1))
 
             is PhotoDetailIntent.PageChanged -> {
-                reduce { copy(currentIndex = intent.index) }
-                preloadIfNeeded(intent.index, reduce)
+                reduce { copy(currentPage = intent.page) }
+                preloadIfNeeded(reduce)
             }
 
             // ActionBar Intent
@@ -168,11 +158,10 @@ class PhotoDetailViewModel @AssistedInject constructor(
     }
 
     private fun preloadIfNeeded(
-        currentIndex: Int,
         reduce: (PhotoDetailState.() -> PhotoDetailState) -> Unit,
     ) {
         val latestState = store.uiState.value
-        if (currentIndex >= latestState.photos.size - PRELOAD_THRESHOLD && hasNext && !isLoadingMore) {
+        if (latestState.currentIndex >= latestState.photos.size - PRELOAD_THRESHOLD && hasNext && !isLoadingMore) {
             loadMorePhotos(reduce)
         }
     }
@@ -219,6 +208,6 @@ class PhotoDetailViewModel @AssistedInject constructor(
 
     companion object {
         private const val PAGE_SIZE = 5
-        private const val PRELOAD_THRESHOLD = 3
+        private const val PRELOAD_THRESHOLD = 5
     }
 }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/const/PoseConst.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/const/PoseConst.kt
@@ -2,8 +2,7 @@ package com.neki.android.feature.pose.impl.const
 
 internal object PoseConst {
     internal const val INITIAL_POSE_LOAD_COUNT = 4
-    internal const val POSE_PREFETCH_THRESHOLD = 3
-    internal const val MAXIMUM_RANDOM_POSE_RETRY_COUNT = 7
+    internal const val POSE_PREFETCH_THRESHOLD = 5
 
     internal const val POSE_LAYOUT_DEFAULT_TOP_PADDING = 12
     internal const val POSE_LAYOUT_BOTTOM_PADDING = 28

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseContract.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseContract.kt
@@ -6,7 +6,7 @@ import kotlinx.collections.immutable.persistentListOf
 
 data class RandomPoseState(
     val isLoading: Boolean = false,
-    val isShowTutorial: Boolean = true,
+    val isShowTutorial: Boolean = false,
     val currentPage: Int = 0,
     val poseList: ImmutableList<Pose> = persistentListOf(),
     val committedBookmarks: Map<Long, Boolean> = emptyMap(),

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseContract.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseContract.kt
@@ -7,16 +7,16 @@ import kotlinx.collections.immutable.persistentListOf
 data class RandomPoseState(
     val isLoading: Boolean = false,
     val isShowTutorial: Boolean = true,
-    val currentIndex: Int = 0,
+    val currentPage: Int = 0,
     val poseList: ImmutableList<Pose> = persistentListOf(),
     val committedBookmarks: Map<Long, Boolean> = emptyMap(),
     val hasNewPose: Boolean = true,
 ) {
+    val currentIndex: Int
+        get() = if (poseList.isEmpty()) 0 else currentPage % poseList.size
+
     val currentPose: Pose?
         get() = poseList.getOrNull(currentIndex)
-
-    val hasPrevious: Boolean
-        get() = currentIndex > 0
 
     val randomPoseIds: Set<Long>
         get() = poseList.map { it.id }.toSet()
@@ -34,7 +34,7 @@ sealed interface RandomPoseIntent {
     data object ClickBookmarkIcon : RandomPoseIntent
     data object ClickLeftSwipe : RandomPoseIntent
     data object ClickRightSwipe : RandomPoseIntent
-    data class PageChanged(val index: Int) : RandomPoseIntent
+    data class PageChanged(val page: Int) : RandomPoseIntent
     data class BookmarkChanged(val poseId: Long, val isBookmarked: Boolean) : RandomPoseIntent
 }
 

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseScreen.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseScreen.kt
@@ -42,7 +42,7 @@ internal fun RandomPoseRoute(
     val uiState by viewModel.store.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val nekiToast = remember { NekiToast(context) }
-    val pagerState = rememberPagerState { uiState.poseList.size }
+    val pagerState = rememberPagerState(initialPage = uiState.currentPage) { Int.MAX_VALUE }
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(pagerState) {
@@ -76,7 +76,7 @@ internal fun RandomPoseRoute(
 internal fun RandomPoseScreen(
     uiState: RandomPoseState = RandomPoseState(),
     onIntent: (RandomPoseIntent) -> Unit = {},
-    pagerState: PagerState = rememberPagerState { uiState.poseList.size },
+    pagerState: PagerState = rememberPagerState { Int.MAX_VALUE },
 ) {
     val hazeState = rememberHazeState()
 

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseViewModel.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseViewModel.kt
@@ -56,26 +56,18 @@ internal class RandomPoseViewModel @AssistedInject constructor(
 
             // 튜토리얼
             RandomPoseIntent.ClickLeftSwipe -> {
-                if (state.hasPrevious) {
-                    postSideEffect(RandomPoseEffect.AnimateToPage(state.currentIndex - 1))
-                } else {
-                    postSideEffect(RandomPoseEffect.ShowToast("첫번째 포즈입니다."))
+                if (state.currentPage > 0) {
+                    postSideEffect(RandomPoseEffect.AnimateToPage(state.currentPage - 1))
                 }
             }
 
             RandomPoseIntent.ClickRightSwipe -> {
-                if (state.currentIndex < state.poseList.lastIndex) {
-                    postSideEffect(RandomPoseEffect.AnimateToPage(state.currentIndex + 1))
-                } else if (!state.hasNewPose) {
-                    postSideEffect(RandomPoseEffect.ShowToast("모든 포즈를 불러왔어요"))
-                } else {
-                    postSideEffect(RandomPoseEffect.ShowToast("새로운 포즈를 불러오고 있어요"))
-                }
+                postSideEffect(RandomPoseEffect.AnimateToPage(state.currentPage + 1))
             }
 
             is RandomPoseIntent.PageChanged -> {
-                reduce { copy(currentIndex = intent.index) }
-                prefetchIfNeeded(intent.index, state, reduce, postSideEffect)
+                reduce { copy(currentPage = intent.page) }
+                prefetchIfNeeded(reduce)
             }
 
             RandomPoseIntent.ClickStartRandomPose -> reduce { copy(isShowTutorial = false) }
@@ -147,13 +139,11 @@ internal class RandomPoseViewModel @AssistedInject constructor(
     }
 
     private fun prefetchIfNeeded(
-        currentIndex: Int,
-        state: RandomPoseState,
         reduce: (RandomPoseState.() -> RandomPoseState) -> Unit,
-        postSideEffect: (RandomPoseEffect) -> Unit,
     ) {
+        val state = store.uiState.value
         if (state.poseList.isEmpty()) return
-        if (state.poseList.lastIndex - currentIndex < PoseConst.POSE_PREFETCH_THRESHOLD && state.hasNewPose) {
+        if (state.currentIndex >= state.poseList.size - PoseConst.POSE_PREFETCH_THRESHOLD && state.hasNewPose) {
             viewModelScope.launch {
                 poseRepository.getSingleRandomPose(
                     headCount = peopleCount,
@@ -216,7 +206,7 @@ internal class RandomPoseViewModel @AssistedInject constructor(
                         isLoading = false,
                         poseList = data.toImmutableList(),
                         committedBookmarks = data.associate { it.id to it.isBookmarked },
-                        currentIndex = 0,
+                        currentPage = 0,
                     )
                 }
             }.onFailure { e ->

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseViewModel.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseViewModel.kt
@@ -178,9 +178,8 @@ internal class RandomPoseViewModel @AssistedInject constructor(
     ) {
         viewModelScope.launch {
             if (!userRepository.hasVisitedRandomPose.first()) {
+                reduce { copy(isShowTutorial = true) }
                 userRepository.setRandomPoseVisited()
-            } else {
-                reduce { copy(isShowTutorial = false) }
             }
         }
     }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/component/RandomPoseImagePager.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/component/RandomPoseImagePager.kt
@@ -41,7 +41,7 @@ internal fun RandomPoseImagePager(
     ) { page ->
         val index = if (poseList.isEmpty()) 0 else page % poseList.size
         RandomPoseImage(
-            pose = poseList[index],
+            pose = poseList.getOrElse(index) { Pose() },
             onLeftSwipe = onLeftSwipe,
             onRightSwipe = onRightSwipe,
         )

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/component/RandomPoseImagePager.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/component/RandomPoseImagePager.kt
@@ -38,7 +38,8 @@ internal fun RandomPoseImagePager(
         state = pagerState,
         beyondViewportPageCount = PoseConst.POSE_PREFETCH_THRESHOLD,
         userScrollEnabled = true,
-    ) { index ->
+    ) { page ->
+        val index = if (poseList.isEmpty()) 0 else page % poseList.size
         RandomPoseImage(
             pose = poseList[index],
             onLeftSwipe = onLeftSwipe,


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #149

## 📙 작업 설명
- 사진 상세, 랜덤포즈 페이저에서 마지막 페이지 이후 오른쪽 스와이프 시 첫 페이지부터 다시 순환되도록 무한 스크롤 구현
- `Int.MAX_VALUE` pageCount + 모듈러 인덱스 방식으로 자연스러운 순환 구현
- 데이터 로딩 중에도 끊김 없이 스와이프 가능하며, preload threshold 조정으로 콘텐츠 전환 안정성 확보
- 빈 리스트 방어 처리 및 stale state 이슈 수정

## 📸 스크린샷 또는 시연 영상 (선택)
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| 사진 상세 무한 스크롤 | <video src="https://github.com/user-attachments/assets/db75f700-4a8e-4ba9-a301-88570445bd43" width="250"></video> | 랜덤포즈 무한 스크롤 | <video src="https://github.com/user-attachments/assets/442ec912-a2bc-43d1-a943-86b2e57b1422" width="250"></video> |

## 💬 추가 설명 or 리뷰 포인트 (선택)
- `currentIndex` → `currentPage`로 변경하여 pager page 번호와 실제 리스트 인덱스를 분리 (`currentIndex`는 `currentPage % size`로 computed property 처리)
- `beyondViewportPageCount = 1` 추가로 스와이프 시 빈 화면 방지 (PhotoDetail)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 사진 및 포즈 갤러리에서 무한 순환 페이징 동작 개선으로 더 부드러운 스와이프 환경 제공
  * 경계 도달 시 불필요한 알림 제거

* **개선 사항**
  * 페이지 전환 애니메이션 성능 최적화
  * 프리페치 임계값 조정으로 콘텐츠 로딩 효율성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->