### PR TITLE
[feat] #154 사진 추가 시 아카이빙 메인 화면 재갱신

### DIFF
--- a/app/src/main/java/com/neki/android/app/main/MainContract.kt
+++ b/app/src/main/java/com/neki/android/app/main/MainContract.kt
@@ -30,4 +30,5 @@ sealed interface MainSideEffect {
     data class NavigateToUploadAlbumWithGallery(val uriStrings: List<String>) : MainSideEffect
     data class NavigateToUploadAlbumWithQRScan(val imageUrl: String) : MainSideEffect
     data class ShowToast(val message: String) : MainSideEffect
+    data object RefreshArchive : MainSideEffect
 }

--- a/app/src/main/java/com/neki/android/app/main/MainScreen.kt
+++ b/app/src/main/java/com/neki/android/app/main/MainScreen.kt
@@ -33,6 +33,7 @@ import com.neki.android.core.ui.component.LoadingDialog
 import com.neki.android.core.ui.compose.collectWithLifecycle
 import com.neki.android.core.ui.toast.NekiToast
 import com.neki.android.feature.archive.api.ArchiveNavKey
+import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.map.api.MapNavKey
 import com.neki.android.feature.mypage.api.MyPageNavKey
 import com.neki.android.feature.photo_upload.api.PhotoUploadNavKey
@@ -85,6 +86,7 @@ fun MainRoute(
             is MainSideEffect.NavigateToUploadAlbumWithGallery -> navigateToUploadAlbumWithGallery(sideEffect.uriStrings)
             is MainSideEffect.NavigateToUploadAlbumWithQRScan -> navigateToUploadAlbumWithQRScan(sideEffect.imageUrl)
             is MainSideEffect.ShowToast -> nekiToast.showToast(sideEffect.message)
+            MainSideEffect.RefreshArchive -> resultBus.sendResult<ArchiveResult>(result = ArchiveResult.PhotoUploaded)
         }
     }
 

--- a/app/src/main/java/com/neki/android/app/main/MainViewModel.kt
+++ b/app/src/main/java/com/neki/android/app/main/MainViewModel.kt
@@ -104,6 +104,7 @@ class MainViewModel @Inject constructor(
                 .onSuccess {
                     reduce { copy(isLoading = false, scannedImageUrl = null) }
                     postSideEffect(MainSideEffect.ShowToast("이미지를 추가했어요"))
+                    postSideEffect(MainSideEffect.RefreshArchive)
                 }
                 .onFailure { e ->
                     Timber.e(e)
@@ -125,6 +126,7 @@ class MainViewModel @Inject constructor(
                 .onSuccess {
                     reduce { copy(isLoading = false, selectedUris = persistentListOf()) }
                     postSideEffect(MainSideEffect.ShowToast("이미지를 추가했어요"))
+                    postSideEffect(MainSideEffect.RefreshArchive)
                 }
                 .onFailure { e ->
                     Timber.e(e)

--- a/core/navigation/src/main/java/com/neki/android/core/navigation/result/ResultEventBus.kt
+++ b/core/navigation/src/main/java/com/neki/android/core/navigation/result/ResultEventBus.kt
@@ -3,7 +3,9 @@ package com.neki.android.core.navigation.result
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.ProvidedValue
+import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.mutableStateMapOf
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.BUFFERED
@@ -33,8 +35,9 @@ object LocalResultEventBus {
  * It provides a solution for event based results.
  */
 // https://github.com/android/nav3-recipes/blob/main/app/src/main/java/com/example/nav3recipes/results/event/README.md
+@Stable
 class ResultEventBus {
-    val channelMap: MutableMap<String, Channel<Any?>> = mutableMapOf()
+    val channelMap: MutableMap<String, Channel<Any?>> = mutableStateMapOf()
 
     inline fun <reified T> getResultFlow(resultKey: String = T::class.toString()) =
         channelMap[resultKey]?.receiveAsFlow()

--- a/core/navigation/src/main/java/com/neki/android/core/navigation/result/ResultEventBus.kt
+++ b/core/navigation/src/main/java/com/neki/android/core/navigation/result/ResultEventBus.kt
@@ -3,7 +3,6 @@ package com.neki.android.core.navigation.result
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.ProvidedValue
-import androidx.compose.runtime.Stable
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.mutableStateMapOf
 import kotlinx.coroutines.channels.BufferOverflow
@@ -35,7 +34,6 @@ object LocalResultEventBus {
  * It provides a solution for event based results.
  */
 // https://github.com/android/nav3-recipes/blob/main/app/src/main/java/com/example/nav3recipes/results/event/README.md
-@Stable
 class ResultEventBus {
     val channelMap = mutableStateMapOf<String, Channel<Any?>>()
 

--- a/core/navigation/src/main/java/com/neki/android/core/navigation/result/ResultEventBus.kt
+++ b/core/navigation/src/main/java/com/neki/android/core/navigation/result/ResultEventBus.kt
@@ -37,7 +37,7 @@ object LocalResultEventBus {
 // https://github.com/android/nav3-recipes/blob/main/app/src/main/java/com/example/nav3recipes/results/event/README.md
 @Stable
 class ResultEventBus {
-    val channelMap: MutableMap<String, Channel<Any?>> = mutableStateMapOf()
+    val channelMap = mutableStateMapOf<String, Channel<Any?>>()
 
     inline fun <reified T> getResultFlow(resultKey: String = T::class.toString()) =
         channelMap[resultKey]?.receiveAsFlow()

--- a/feature/archive/api/src/main/kotlin/com/neki/android/feature/archive/api/ArchiveResult.kt
+++ b/feature/archive/api/src/main/kotlin/com/neki/android/feature/archive/api/ArchiveResult.kt
@@ -6,4 +6,6 @@ sealed interface ArchiveResult {
     }
 
     data class FavoriteChanged(val photoId: Long, val isFavorite: Boolean) : ArchiveResult
+
+    data object PhotoUploaded : ArchiveResult
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainContract.kt
@@ -1,10 +1,8 @@
 package com.neki.android.feature.archive.impl.main
 
-import android.net.Uri
 import androidx.compose.foundation.text.input.TextFieldState
 import com.neki.android.core.model.AlbumPreview
 import com.neki.android.core.model.Photo
-import com.neki.android.core.model.UploadType
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -14,15 +12,9 @@ data class ArchiveMainState(
     val favoriteAlbum: AlbumPreview = AlbumPreview(title = "즐겨찾는사진"),
     val albums: ImmutableList<AlbumPreview> = persistentListOf(),
     val recentPhotos: ImmutableList<Photo> = persistentListOf(),
-    val scannedImageUrl: String? = null,
-    val selectedUris: ImmutableList<Uri> = persistentListOf(),
-    val isShowSelectWithAlbumDialog: Boolean = false,
     val isShowAddAlbumBottomSheet: Boolean = false,
     val albumNameTextState: TextFieldState = TextFieldState(),
-) {
-    val uploadType: UploadType
-        get() = if (scannedImageUrl != null) UploadType.QR_CODE else UploadType.GALLERY
-}
+)
 
 sealed interface ArchiveMainIntent {
     data object EnterArchiveMainScreen : ArchiveMainIntent
@@ -33,11 +25,6 @@ sealed interface ArchiveMainIntent {
     // TopBar Intent
     data object DismissToolTipPopup : ArchiveMainIntent
     data object ClickQRScanIcon : ArchiveMainIntent
-
-    data class SelectGalleryImage(val uris: List<Uri>) : ArchiveMainIntent
-    data object DismissSelectWithAlbumDialog : ArchiveMainIntent
-    data object ClickUploadWithAlbumRow : ArchiveMainIntent
-    data object ClickUploadWithoutAlbumRow : ArchiveMainIntent
     data object ClickNotificationIcon : ArchiveMainIntent
 
     // Album Intent
@@ -54,16 +41,10 @@ sealed interface ArchiveMainIntent {
     // Add Album BottomSheet Intent
     data object DismissAddAlbumBottomSheet : ArchiveMainIntent
     data object ClickAddAlbumButton : ArchiveMainIntent
-
-    // Result
-    data class QRCodeScanned(val imageUrl: String) : ArchiveMainIntent
-    data object ReceiveOpenGalleryResult : ArchiveMainIntent
 }
 
 sealed interface ArchiveMainSideEffect {
     data object NavigateToQRScan : ArchiveMainSideEffect
-    data class NavigateToUploadAlbumWithGallery(val uriStrings: List<String>) : ArchiveMainSideEffect
-    data class NavigateToUploadAlbumWithQRScan(val imageUrl: String) : ArchiveMainSideEffect
     data object NavigateToAllAlbum : ArchiveMainSideEffect
     data class NavigateToFavoriteAlbum(val albumId: Long) : ArchiveMainSideEffect
     data class NavigateToAlbumDetail(val albumId: Long, val title: String) : ArchiveMainSideEffect
@@ -71,6 +52,5 @@ sealed interface ArchiveMainSideEffect {
     data class NavigateToPhotoDetail(val photos: List<Photo>, val index: Int) : ArchiveMainSideEffect
 
     data object ScrollToTop : ArchiveMainSideEffect
-    data object OpenGallery : ArchiveMainSideEffect
     data class ShowToastMessage(val message: String) : ArchiveMainSideEffect
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainContract.kt
@@ -26,7 +26,7 @@ data class ArchiveMainState(
 
 sealed interface ArchiveMainIntent {
     data object EnterArchiveMainScreen : ArchiveMainIntent
-    data object RefreshArchiveMainScreen : ArchiveMainIntent
+    data object RefreshArchiveMainPhotos : ArchiveMainIntent
     data object ClickScreen : ArchiveMainIntent
     data object ClickGoToTopButton : ArchiveMainIntent
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainScreen.kt
@@ -1,8 +1,5 @@
 package com.neki.android.feature.archive.impl.main
 
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -40,23 +37,18 @@ import com.neki.android.core.ui.toast.NekiToast
 import com.neki.android.feature.archive.impl.component.AddAlbumBottomSheet
 import com.neki.android.feature.archive.impl.const.ArchiveConst.ARCHIVE_GRID_ITEM_SPACING
 import com.neki.android.feature.archive.impl.const.ArchiveConst.PHOTO_GRAY_LAYOUT_BOTTOM_PADDING
-import com.neki.android.feature.archive.impl.main.component.AlbumUploadOption
 import com.neki.android.feature.archive.impl.main.component.ArchiveMainAlbumList
 import com.neki.android.feature.archive.impl.main.component.ArchiveMainPhotoItem
 import com.neki.android.feature.archive.impl.main.component.ArchiveMainTitleRow
 import com.neki.android.feature.archive.impl.main.component.ArchiveMainTopBar
 import com.neki.android.feature.archive.impl.component.EmptyPhotoContent
 import com.neki.android.feature.archive.impl.main.component.GotoTopButton
-import com.neki.android.feature.archive.impl.main.component.SelectWithAlbumDialog
 import kotlinx.collections.immutable.persistentListOf
-import timber.log.Timber
 
 @Composable
 internal fun ArchiveMainRoute(
     viewModel: ArchiveMainViewModel = hiltViewModel(),
     navigateToQRScan: () -> Unit,
-    navigateToUploadAlbumWithGallery: (List<String>) -> Unit,
-    navigateToUploadAlbumWithQRScan: (String) -> Unit,
     navigateToAllAlbum: () -> Unit,
     navigateToFavoriteAlbum: (Long) -> Unit,
     navigateToAlbumDetail: (Long, String) -> Unit,
@@ -67,19 +59,10 @@ internal fun ArchiveMainRoute(
     val context = LocalContext.current
     val lazyState = rememberLazyStaggeredGridState()
     val nekiToast = remember { NekiToast(context) }
-    val photoPicker = rememberLauncherForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(10)) { uris ->
-        if (uris.isNotEmpty()) {
-            viewModel.store.onIntent(ArchiveMainIntent.SelectGalleryImage(uris))
-        } else {
-            Timber.d("No media selected")
-        }
-    }
 
     viewModel.store.sideEffects.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             ArchiveMainSideEffect.NavigateToQRScan -> navigateToQRScan()
-            is ArchiveMainSideEffect.NavigateToUploadAlbumWithGallery -> navigateToUploadAlbumWithGallery(sideEffect.uriStrings)
-            is ArchiveMainSideEffect.NavigateToUploadAlbumWithQRScan -> navigateToUploadAlbumWithQRScan(sideEffect.imageUrl)
             ArchiveMainSideEffect.NavigateToAllAlbum -> navigateToAllAlbum()
             is ArchiveMainSideEffect.NavigateToFavoriteAlbum -> navigateToFavoriteAlbum(sideEffect.albumId)
             is ArchiveMainSideEffect.NavigateToAlbumDetail -> navigateToAlbumDetail(sideEffect.albumId, sideEffect.title)
@@ -88,7 +71,6 @@ internal fun ArchiveMainRoute(
                 ArchiveNavKey.PhotoDetail(photos = sideEffect.photos, initialIndex = sideEffect.index),
             )
             ArchiveMainSideEffect.ScrollToTop -> lazyState.animateScrollToItem(0)
-            ArchiveMainSideEffect.OpenGallery -> photoPicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
             is ArchiveMainSideEffect.ShowToastMessage -> nekiToast.showToast(text = sideEffect.message)
         }
     }
@@ -115,7 +97,6 @@ internal fun ArchiveMainScreen(
             ArchiveMainTopBar(
                 showTooltip = uiState.isFirstEntered,
                 onClickQRCodeIcon = { onIntent(ArchiveMainIntent.ClickQRScanIcon) },
-//                onClickNotificationIcon = { onIntent(ArchiveMainIntent.ClickNotificationIcon) },
                 onDismissToolTipPopup = { onIntent(ArchiveMainIntent.DismissToolTipPopup) },
             )
             ArchiveMainContent(
@@ -164,18 +145,6 @@ internal fun ArchiveMainScreen(
             onClickConfirm = { onIntent(ArchiveMainIntent.ClickAddAlbumButton) },
             isError = errorMessage != null,
             errorMessage = errorMessage,
-        )
-    }
-
-    if (uiState.isShowSelectWithAlbumDialog) {
-        SelectWithAlbumDialog(
-            onDismissRequest = { onIntent(ArchiveMainIntent.DismissSelectWithAlbumDialog) },
-            onSelect = { option ->
-                when (option) {
-                    AlbumUploadOption.WITHOUT_ALBUM -> onIntent(ArchiveMainIntent.ClickUploadWithoutAlbumRow)
-                    AlbumUploadOption.WITH_ALBUM -> onIntent(ArchiveMainIntent.ClickUploadWithAlbumRow)
-                }
-            },
         )
     }
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
@@ -1,20 +1,15 @@
 package com.neki.android.feature.archive.impl.main
 
-import android.net.Uri
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.neki.android.core.dataapi.repository.FolderRepository
 import com.neki.android.core.dataapi.repository.PhotoRepository
 import com.neki.android.core.dataapi.repository.UserRepository
-import com.neki.android.core.domain.usecase.UploadMultiplePhotoUseCase
-import com.neki.android.core.domain.usecase.UploadSinglePhotoUseCase
 import com.neki.android.core.model.Photo
-import com.neki.android.core.model.UploadType
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -28,8 +23,6 @@ private const val DEFAULT_PHOTOS_SIZE = 20
 
 @HiltViewModel
 class ArchiveMainViewModel @Inject constructor(
-    private val uploadSinglePhotoUseCase: UploadSinglePhotoUseCase,
-    private val uploadMultiplePhotoUseCase: UploadMultiplePhotoUseCase,
     private val photoRepository: PhotoRepository,
     private val folderRepository: FolderRepository,
     private val userRepository: UserRepository,
@@ -63,30 +56,6 @@ class ArchiveMainViewModel @Inject constructor(
             }
 
             ArchiveMainIntent.ClickQRScanIcon -> postSideEffect(ArchiveMainSideEffect.NavigateToQRScan)
-
-            is ArchiveMainIntent.SelectGalleryImage -> reduce {
-                copy(
-                    isShowSelectWithAlbumDialog = true,
-                    selectedUris = intent.uris.toImmutableList(),
-                )
-            }
-
-            ArchiveMainIntent.DismissSelectWithAlbumDialog -> reduce { copy(isShowSelectWithAlbumDialog = false) }
-            ArchiveMainIntent.ClickUploadWithAlbumRow -> {
-                reduce {
-                    copy(
-                        isShowSelectWithAlbumDialog = false,
-                        scannedImageUrl = null,
-                        selectedUris = persistentListOf(),
-                    )
-                }
-                if (state.scannedImageUrl == null)
-                    postSideEffect(ArchiveMainSideEffect.NavigateToUploadAlbumWithGallery(state.selectedUris.map { it.toString() }))
-                else postSideEffect(ArchiveMainSideEffect.NavigateToUploadAlbumWithQRScan(state.scannedImageUrl))
-            }
-
-            ArchiveMainIntent.ClickUploadWithoutAlbumRow -> uploadWithoutAlbum(state, reduce, postSideEffect)
-
             ArchiveMainIntent.ClickNotificationIcon -> {}
 
             // Album Intent
@@ -103,16 +72,6 @@ class ArchiveMainViewModel @Inject constructor(
             // Add Album BottomSheet Intent
             ArchiveMainIntent.DismissAddAlbumBottomSheet -> reduce { copy(isShowAddAlbumBottomSheet = false) }
             ArchiveMainIntent.ClickAddAlbumButton -> handleAddAlbum(state.albumNameTextState.text.trim().toString(), reduce, postSideEffect)
-
-            // Result
-            is ArchiveMainIntent.QRCodeScanned -> reduce {
-                copy(
-                    scannedImageUrl = intent.imageUrl,
-                    isShowSelectWithAlbumDialog = true,
-                )
-            }
-
-            ArchiveMainIntent.ReceiveOpenGalleryResult -> postSideEffect(ArchiveMainSideEffect.OpenGallery)
         }
     }
 
@@ -168,77 +127,6 @@ class ArchiveMainViewModel @Inject constructor(
             .onFailure { e ->
                 Timber.e(e)
             }
-    }
-
-    private fun uploadWithoutAlbum(
-        state: ArchiveMainState,
-        reduce: (ArchiveMainState.() -> ArchiveMainState) -> Unit,
-        postSideEffect: (ArchiveMainSideEffect) -> Unit,
-    ) {
-        reduce { copy(isShowSelectWithAlbumDialog = false) }
-        val onSuccessSideEffect = {
-            reduce { copy(isLoading = false) }
-            postSideEffect(ArchiveMainSideEffect.ShowToastMessage("이미지를 추가했어요"))
-        }
-        if (state.uploadType == UploadType.QR_CODE) {
-            uploadSingleImage(
-                imageUrl = state.scannedImageUrl ?: return,
-                reduce = reduce,
-                postSideEffect = postSideEffect,
-                onSuccess = onSuccessSideEffect,
-            )
-        } else {
-            uploadMultipleImages(
-                imageUris = state.selectedUris,
-                reduce = reduce,
-                postSideEffect = postSideEffect,
-                onSuccess = onSuccessSideEffect,
-            )
-        }
-    }
-
-    private fun uploadSingleImage(
-        imageUrl: String,
-        reduce: (ArchiveMainState.() -> ArchiveMainState) -> Unit,
-        postSideEffect: (ArchiveMainSideEffect) -> Unit,
-        onSuccess: () -> Unit,
-    ) {
-        viewModelScope.launch {
-            reduce { copy(isLoading = true) }
-
-            uploadSinglePhotoUseCase(
-                imageUrl = imageUrl,
-            ).onSuccess {
-                fetchPhotos(reduce) // 가장 최신 데이터 가져오기
-                onSuccess()
-            }.onFailure { e ->
-                Timber.e(e)
-                postSideEffect(ArchiveMainSideEffect.ShowToastMessage("이미지 업로드에 실패했어요"))
-                reduce { copy(isLoading = false) }
-            }
-        }
-    }
-
-    private fun uploadMultipleImages(
-        imageUris: List<Uri>,
-        reduce: (ArchiveMainState.() -> ArchiveMainState) -> Unit,
-        postSideEffect: (ArchiveMainSideEffect) -> Unit,
-        onSuccess: () -> Unit,
-    ) {
-        viewModelScope.launch {
-            reduce { copy(isLoading = true) }
-
-            uploadMultiplePhotoUseCase(
-                imageUris = imageUris,
-            ).onSuccess {
-                fetchPhotos(reduce)
-                onSuccess()
-            }.onFailure { e ->
-                Timber.e(e)
-                postSideEffect(ArchiveMainSideEffect.ShowToastMessage("이미지 업로드에 실패했어요"))
-                reduce { copy(isLoading = false) }
-            }
-        }
     }
 
     private fun handleFavoriteToggle(

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
@@ -151,7 +151,7 @@ class ArchiveMainViewModel @Inject constructor(
     }
 
     private suspend fun fetchPhotos(reduce: (ArchiveMainState.() -> ArchiveMainState) -> Unit, size: Int = DEFAULT_PHOTOS_SIZE) {
-        photoRepository.getPhotos()
+        photoRepository.getPhotos(size = size)
             .onSuccess { data ->
                 reduce { copy(recentPhotos = data.toImmutableList()) }
             }
@@ -209,7 +209,7 @@ class ArchiveMainViewModel @Inject constructor(
             uploadSinglePhotoUseCase(
                 imageUrl = imageUrl,
             ).onSuccess {
-                fetchPhotos(reduce, 1) // 가장 최신 데이터 가져오기
+                fetchPhotos(reduce) // 가장 최신 데이터 가져오기
                 onSuccess()
             }.onFailure { e ->
                 Timber.e(e)

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
@@ -52,7 +52,7 @@ class ArchiveMainViewModel @Inject constructor(
         if (intent != ArchiveMainIntent.EnterArchiveMainScreen) reduce { copy(isFirstEntered = false) }
         when (intent) {
             ArchiveMainIntent.EnterArchiveMainScreen -> fetchInitialData(reduce)
-            ArchiveMainIntent.RefreshArchiveMainScreen -> fetchInitialData(reduce)
+            ArchiveMainIntent.RefreshArchiveMainPhotos -> viewModelScope.launch { fetchPhotos(reduce) }
             ArchiveMainIntent.ClickScreen -> reduce { copy(isFirstEntered = false) }
             ArchiveMainIntent.ClickGoToTopButton -> postSideEffect(ArchiveMainSideEffect.ScrollToTop)
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
@@ -60,8 +60,13 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
                 }
             }
         }
-        ResultEffect<ArchiveResult>(resultBus) {
-            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMainScreen)
+        ResultEffect<ArchiveResult>(resultBus) { result ->
+            when (result) {
+                is ArchiveResult.FavoriteChanged,
+                is ArchiveResult.PhotoDeleted,
+                ArchiveResult.PhotoUploaded,
+                    -> viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMainScreen)
+            }
         }
 
         ArchiveMainRoute(
@@ -94,6 +99,8 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
                 is ArchiveResult.PhotoDeleted -> {
                     viewModel.store.onIntent(AllPhotoIntent.PhotoDeleted(result.photoId))
                 }
+
+                else -> {}
             }
         }
 
@@ -131,6 +138,8 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
                 is ArchiveResult.PhotoDeleted -> {
                     viewModel.store.onIntent(AlbumDetailIntent.PhotoDeleted(result.photoId))
                 }
+
+                else -> {}
             }
         }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
@@ -65,7 +65,7 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
                 is ArchiveResult.FavoriteChanged,
                 is ArchiveResult.PhotoDeleted,
                 ArchiveResult.PhotoUploaded,
-                    -> viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMainScreen)
+                    -> viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMainPhotos)
             }
         }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
@@ -25,9 +25,7 @@ import com.neki.android.feature.archive.impl.photo.AllPhotoRoute
 import com.neki.android.feature.archive.impl.photo.AllPhotoViewModel
 import com.neki.android.feature.archive.impl.photo_detail.PhotoDetailRoute
 import com.neki.android.feature.archive.impl.photo_detail.PhotoDetailViewModel
-import com.neki.android.feature.photo_upload.api.QRScanResult
 import com.neki.android.feature.photo_upload.api.navigateToQRScan
-import com.neki.android.feature.photo_upload.api.navigateToUploadAlbum
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -49,31 +47,16 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
     entry<ArchiveNavKey.Archive> {
         val resultBus = LocalResultEventBus.current
         val viewModel = hiltViewModel<ArchiveMainViewModel>()
-        ResultEffect<QRScanResult>(resultBus) { result ->
-            when (result) {
-                is QRScanResult.QRCodeScanned -> {
-                    viewModel.store.onIntent(ArchiveMainIntent.QRCodeScanned(result.imageUrl))
-                }
-
-                QRScanResult.OpenGallery -> {
-                    viewModel.store.onIntent(ArchiveMainIntent.ReceiveOpenGalleryResult)
-                }
-            }
-        }
         ResultEffect<ArchiveResult>(resultBus) { result ->
             when (result) {
-                is ArchiveResult.FavoriteChanged,
-                is ArchiveResult.PhotoDeleted,
-                ArchiveResult.PhotoUploaded,
-                    -> viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMainPhotos)
+                is ArchiveResult.FavoriteChanged, is ArchiveResult.PhotoDeleted, ArchiveResult.PhotoUploaded ->
+                    viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMainPhotos)
             }
         }
 
         ArchiveMainRoute(
             viewModel = viewModel,
             navigateToQRScan = navigator::navigateToQRScan,
-            navigateToUploadAlbumWithGallery = navigator::navigateToUploadAlbum,
-            navigateToUploadAlbumWithQRScan = navigator::navigateToUploadAlbum,
             navigateToAllAlbum = navigator::navigateToAllAlbum,
             navigateToFavoriteAlbum = { id ->
                 navigator.navigateToAlbumDetail(id = id, isFavorite = true)


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #154 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- Photo Upload 모듈에서 QR 혹은 갤러리를 통해 사진 업로드할 때, 기존 ArchiveMain 에서 Result 를 collect 해서 사진정보를 업데이트했지만,
- 새롭게 `Main` 에서 `Result` 를 먼저 `collect` 하여 가로채기 때문에 `ArchiveMain` 쪽에서의 갱신 로직에 다다를 수 없었습니다.
- 따라서 `Main` 에서 `PhotoUpload Result` 를 받으면, `ArchiveMain` 쪽으로 `Result` 를 보내도록 적용했습니다.
- 추가적으로 추후 다른 변경 등으로 인해 `ArchiveMain` 쪽에서 `Result` 를 받을 가능성이 있으니 `when` 으로 처리하도록 했습니다.
- 아카이빙 메인에서의 업로드 관련 로직은 `dead code` 가 되어서 제거했습니다.

아래 케이스들 모두 체크 완료했습니다. (앨범에 추가까지)
1. 아카이빙 탑바 QR 스캔
2. 사진 추가 > 갤러리
3. 사진 추가 > QR 스캔

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|갤러리업로드|기능|QR스캔|
|:--:|:--:|:--:|:--:|
| 사진 추가 > 갤러리 업로드 |<video src="https://github.com/user-attachments/assets/8fa5fab3-fa9a-437a-a289-d3e6e6d26465" width="300" />| 탑바 > QR 스캔 |<video src="https://github.com/user-attachments/assets/11974b0d-120e-4320-8cc0-da5528bfb3bf" width="300" />|

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 기존에 `ArchiveMain` 이 먼저 생긴 상태에서, 그 시점의 `channelMap` 을 캡처해 `LaunchedEffect` 에서 체크합니다.
- 하지만 그 `channelMap` 은 상태가 아니기 때문에 해당 Map 의 변화가 생겨도 `LaunchedEffect` 에서 자동적으로 체크하지 못합니다.
- 따라서 `mutableStateMapOf` 으로 `channelMap` 을 수정해주었고, `ResultEventBus` 에 `@Stable` 어노테이션을 추가했습니다.






<!-- Release 용 PR 본문!
## ✅ 버전명
ex) 8 (1.0.0)

## 📙 업데이트 사항 (작업 PR 및 작업 내용)
-

## 🧪 테스트 확인 사항
- [ ] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [ ] 엣지 케이스 테스트 완료
- [ ] 기존 기능 영향 없음


## 💬 QA 후 업데이트 사항
-
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사진 업로드 완료 시 아카이브가 자동으로 새로고침됩니다.
  * 업로드 완료를 알리는 새로운 결과 타입이 추가되었습니다.

* **개선 사항**
  * 아카이브 갱신 로직이 결과 기반으로 통합되어 일관되게 동작합니다.
  * 업로드 후 알림(토스트) 외에 아카이브 새로고침이 함께 트리거됩니다.

* **제거**
  * 갤러리/앨범 선택 및 QR 스캔을 통한 업로드 관련 UI 및 내비게이션 경로가 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->