### PR TITLE
[chore] #159 중복 적용된 테마 설정 구문 제거

### DIFF
--- a/app/src/main/java/com/neki/android/app/MainActivity.kt
+++ b/app/src/main/java/com/neki/android/app/MainActivity.kt
@@ -7,7 +7,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
-import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation3.runtime.entryProvider
 import com.neki.android.app.main.MainRoute
@@ -57,7 +56,6 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         enableEdgeToEdge()
-        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         setContent {
             NekiTheme {

--- a/app/src/main/java/com/neki/android/app/MainActivity.kt
+++ b/app/src/main/java/com/neki/android/app/MainActivity.kt
@@ -60,8 +60,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge(
             navigationBarStyle = SystemBarStyle.auto(
                 lightScrim = Color.TRANSPARENT,
-                darkScrim = Color.TRANSPARENT
-            )
+                darkScrim = Color.TRANSPARENT,
+            ),
         )
 
         setContent {

--- a/app/src/main/java/com/neki/android/app/MainActivity.kt
+++ b/app/src/main/java/com/neki/android/app/MainActivity.kt
@@ -1,8 +1,10 @@
 package com.neki.android.app
 
+import android.graphics.Color
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.CompositionLocalProvider
@@ -55,7 +57,12 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            navigationBarStyle = SystemBarStyle.auto(
+                lightScrim = Color.TRANSPARENT,
+                darkScrim = Color.TRANSPARENT
+            )
+        )
 
         setContent {
             NekiTheme {

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,11 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Theme.Neki" parent="android:Theme.Material.Light.NoActionBar">
-        <item name="android:windowLightStatusBar">true</item>
-        <item name="android:statusBarColor">@android:color/transparent</item>
-        <item name="android:navigationBarColor">@android:color/transparent</item>
-    </style>
+    <style name="Theme.Neki" parent="android:Theme.Material.Light.NoActionBar" />
 
     <style name="OssLicenses.Theme.OptOutEdgeToEdgeEnforcement" parent="Theme.AppCompat">
         <item name="android:windowOptOutEdgeToEdgeEnforcement" tools:targetApi="35">true</item>


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #159 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- MainActivity의 `setDecorFitsSystemWindows` 구문 제거
- `themes.xml`에 설정된 `style` 설정 제거

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- `enableEdgeToEdge()` 적용 효과와 중복되는 `setDecorFitsSystemWindows`를 제거하고, navigationBar/statusBar 테마 적용이 중복된 부분을 제거했습니다.
<img width="700" height="475" alt="image" src="https://github.com/user-attachments/assets/be5f5c24-4916-443e-af3b-b3b5e5f8d277" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 앱의 엣지‑투‑엣지(전체 화면) 표시가 일관되게 개선되었습니다.
  * 네비게이션 바를 포함한 시스템 UI에 투명 스타일을 적용하여 화면 몰입감을 높였습니다.

* **리팩토링**
  * 테마 설정을 단순화해 유지보수성과 일관성을 향상시켰습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->