### PR TITLE
[Refactor] #162 HttpClient의 토큰 캐싱 옵션 설정 추가 및 일부 API 버전 상향

### DIFF
--- a/build-logic/src/main/java/com/neki/android/buildlogic/extensions/Android.kt
+++ b/build-logic/src/main/java/com/neki/android/buildlogic/extensions/Android.kt
@@ -3,9 +3,9 @@ package com.neki.android.buildlogic.extensions
 import com.android.build.api.dsl.CommonExtension
 import com.neki.android.buildlogic.const.BuildConst
 import org.gradle.api.Project
-import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.dependencies
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 
 internal fun Project.configureAndroid(
     commonExtension: CommonExtension<*, *, *, *, *, *>,
@@ -22,18 +22,14 @@ internal fun Project.configureAndroid(
             targetCompatibility = BuildConst.JAVA_VERSION
         }
 
-        configureAndroidOptions {
-            jvmTarget = BuildConst.JDK_VERSION.toString()
-        }
-
         dependencies {
             add("detektPlugins", libs.findLibrary("detekt.formatting").get())
         }
     }
-}
 
-internal fun CommonExtension<*, *, *, *, *, *>.configureAndroidOptions(
-    block: KotlinJvmOptions.() -> Unit,
-) {
-    (this as ExtensionAware).extensions.configure("kotlinOptions", block)
+    extensions.configure<KotlinAndroidProjectExtension>("kotlin") {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.fromTarget(BuildConst.JDK_VERSION.toString()))
+        }
+    }
 }

--- a/core/data-api/src/main/java/com/neki/android/core/dataapi/auth/AuthCacheManager.kt
+++ b/core/data-api/src/main/java/com/neki/android/core/dataapi/auth/AuthCacheManager.kt
@@ -1,5 +1,0 @@
-package com.neki.android.core.dataapi.auth
-
-interface AuthCacheManager {
-    fun invalidateTokenCache()
-}

--- a/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/TokenRepository.kt
+++ b/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/TokenRepository.kt
@@ -10,5 +10,5 @@ interface TokenRepository {
     fun hasTokens(): Flow<Boolean>
     fun getAccessToken(): Flow<String>
     fun getRefreshToken(): Flow<String>
-    suspend fun clearTokens()
+    suspend fun clearTokensWithAuthCache()
 }

--- a/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
@@ -72,7 +72,6 @@ internal object NetworkModule {
 
             install(Auth) {
                 bearer {
-                    // 개발: 캐시 비활성화 (토큰 만료 짧음), 상용: 캐시 활성화 (성능)
                     cacheTokens = !BuildConfig.DEBUG
 
                     loadTokens {

--- a/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
@@ -105,7 +105,7 @@ internal object NetworkModule {
                                 )
                             } catch (e: Exception) {
                                 Timber.e(e)
-                                tokenRepository.clearTokens()
+                                tokenRepository.clearTokensWithAuthCache()
                                 authEventManager.emitTokenExpired()
                                 null
                             }

--- a/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
@@ -6,7 +6,6 @@ import com.neki.android.core.data.remote.model.request.RefreshTokenRequest
 import com.neki.android.core.data.remote.model.response.AuthResponse
 import com.neki.android.core.data.remote.model.response.BasicResponse
 import com.neki.android.core.data.remote.qualifier.UploadHttpClient
-import com.neki.android.core.dataapi.auth.AuthCacheManager
 import com.neki.android.core.dataapi.auth.AuthEventManager
 import com.neki.android.core.dataapi.repository.TokenRepository
 import dagger.Module
@@ -19,14 +18,12 @@ import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.Auth
-import io.ktor.client.plugins.auth.providers.BearerAuthProvider
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
-import io.ktor.client.plugins.plugin
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
@@ -35,7 +32,6 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.encodedPath
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.flow.first
-import dagger.Lazy
 import kotlinx.serialization.json.Json
 import timber.log.Timber
 import javax.inject.Singleton
@@ -60,19 +56,6 @@ internal object NetworkModule {
         isLenient = true
         ignoreUnknownKeys = true
         explicitNulls = false
-    }
-
-    @Provides
-    @Singleton
-    fun provideAuthCacheManager(
-        httpClient: Lazy<HttpClient>,
-    ): AuthCacheManager = object : AuthCacheManager {
-        override fun invalidateTokenCache() {
-            httpClient.get().plugin(Auth).providers
-                .filterIsInstance<BearerAuthProvider>()
-                .firstOrNull()
-                ?.clearToken()
-        }
     }
 
     @Provides

--- a/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
@@ -89,6 +89,8 @@ internal object NetworkModule {
 
             install(Auth) {
                 bearer {
+                    cacheTokens = false
+
                     loadTokens {
                         if (tokenRepository.hasTokens().first()) {
                             BearerTokens(

--- a/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
@@ -72,7 +72,8 @@ internal object NetworkModule {
 
             install(Auth) {
                 bearer {
-                    cacheTokens = false
+                    // 개발: 캐시 비활성화 (토큰 만료 짧음), 상용: 캐시 활성화 (성능)
+                    cacheTokens = !BuildConfig.DEBUG
 
                     loadTokens {
                         if (tokenRepository.hasTokens().first()) {

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/TokenRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/TokenRepositoryImpl.kt
@@ -5,7 +5,6 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.neki.android.core.common.crypto.CryptoManager
-import com.neki.android.core.dataapi.auth.AuthCacheManager
 import com.neki.android.core.dataapi.repository.TokenRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -14,7 +13,6 @@ import javax.inject.Inject
 
 class TokenRepositoryImpl @Inject constructor(
     @TokenDataStore private val dataStore: DataStore<Preferences>,
-    private val authCacheManager: AuthCacheManager,
 ) : TokenRepository {
 
     companion object {
@@ -30,7 +28,6 @@ class TokenRepositoryImpl @Inject constructor(
             preferences[ACCESS_TOKEN] = CryptoManager.encrypt(accessToken)
             preferences[REFRESH_TOKEN] = CryptoManager.encrypt(refreshToken)
         }
-        authCacheManager.invalidateTokenCache()
     }
 
     override fun hasTokens(): Flow<Boolean> {
@@ -59,6 +56,5 @@ class TokenRepositoryImpl @Inject constructor(
             preferences.remove(ACCESS_TOKEN)
             preferences.remove(REFRESH_TOKEN)
         }
-        authCacheManager.invalidateTokenCache()
     }
 }

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/TokenRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/TokenRepositoryImpl.kt
@@ -6,6 +6,10 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import com.neki.android.core.common.crypto.CryptoManager
 import com.neki.android.core.dataapi.repository.TokenRepository
+import dagger.Lazy
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.auth.authProvider
+import io.ktor.client.plugins.auth.providers.BearerAuthProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import com.neki.android.core.data.local.di.TokenDataStore
@@ -13,6 +17,7 @@ import javax.inject.Inject
 
 class TokenRepositoryImpl @Inject constructor(
     @TokenDataStore private val dataStore: DataStore<Preferences>,
+    private val httpClient: Lazy<HttpClient>,
 ) : TokenRepository {
 
     companion object {
@@ -51,7 +56,8 @@ class TokenRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun clearTokens() {
+    override suspend fun clearTokensWithAuthCache() {
+        httpClient.get().authProvider<BearerAuthProvider>()?.clearToken()
         dataStore.edit { preferences ->
             preferences.remove(ACCESS_TOKEN)
             preferences.remove(REFRESH_TOKEN)

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/main/MyPageViewModel.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/main/MyPageViewModel.kt
@@ -178,7 +178,7 @@ internal class MyPageViewModel @Inject constructor(
     }
 
     private fun logout(postSideEffect: (MyPageEffect) -> Unit) = viewModelScope.launch {
-        tokenRepository.clearTokens()
+        tokenRepository.clearTokensWithAuthCache()
         postSideEffect(MyPageEffect.LogoutWithKakao)
     }
 
@@ -189,7 +189,7 @@ internal class MyPageViewModel @Inject constructor(
         reduce { copy(isLoading = true) }
         authRepository.withdrawAccount()
             .onSuccess {
-                tokenRepository.clearTokens()
+                tokenRepository.clearTokensWithAuthCache()
                 authRepository.setCompletedOnboarding(false)
                 reduce { copy(isLoading = false) }
                 postSideEffect(MyPageEffect.UnlinkWithKakao)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ agp = "8.13.1"
 annotationExperimental = "1.5.1"
 cameraX = "1.5.2"
 composeStableMarker = "1.0.7"
-kotlin = "2.1.0"
+kotlin = "2.3.0"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.3.0"
@@ -11,13 +11,12 @@ espressoCore = "3.7.0"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.9.3"
 composeBom = "2025.08.01"
-jetbrainsKotlinJvm = "2.1.0"
-ksp = "2.1.0-1.0.29"
+jetbrainsKotlinJvm = "2.3.0"
+ksp = "2.3.0"
 appcompat = "1.7.1"
 kotlinxSerializationJson = "1.9.0"
-jetbrainsKotlinJvmVersion = "2.1.0"
-hilt = "2.54"
-ktor = "2.3.12"
+hilt = "2.58"
+ktor = "3.4.0"
 androidxDatastore = "1.1.2"
 kotlinxCoroutines = "1.8.1"
 paging = "3.3.6"
@@ -144,7 +143,7 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrainsKotlinJvmVersion" }
+jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrainsKotlinJvm" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 android-library = { id = "com.android.library", version.ref = "agp" }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR과 연결된 이슈 번호를 명시해주세요 (예: Close #123) -->
- Close #162 

## 📙 작업 설명
<!-- 주요 수정 사항이나 개발 내용을 요약해주세요 -->
- `Ktor` 버전 `3.4.0`으로 상향
- `Kotlin, ksp, hilt` 버전 ktor-3.4.0을 지원하는 최소 버전으로 상향
- 개발기/상용기에 따라 `cacheTokens` 옵션 활성화되도록 `cacheTokens = !BuildConfig.DEBUG` 구문 추가
- 수동으로 토큰을 제거하던 `AuthCacheManager` 제거

## 🧪 테스트 내역 (선택)
- [x] 개발기에서 AccessToken, RefreshToken 만료 시 각각 AccessToken 갱신 및 로그인 화면으로 이동하는 것 확인했습니다.

## 💬 추가 설명 or 리뷰 포인트 (선택)
<!-- 리뷰어가 중점적으로 봐야 할 부분이나 설명이 필요한 내용을 자유롭게 작성해주세요 -->
- 현재 서버의 Access/Refresh 토큰의 만료 주기가 상용 : 1시간/14일, 개발 : 1시간/2시간 설정되어 있고, 상용기에서는 비교적 RefreshToken의 만료 주기가 길기 때문에 불필요한 `TokenRepository` 조회 횟수를 줄이기 위해 `cacheTokens` 옵션을 활성화 할 수 있도록 했습니다.

---
Q. 토끼 리뷰에 따라 로그아웃/탈퇴 시 `HttpClient`에 저장된 토큰을 명시적으로 제거해 주어야 해서 반영했습니다. [0a2c091](https://github.com/YAPP-Github/27th-App-Team-2-Android/pull/163/commits/0a2c0916a7bfffe68f2de4d762b12603b09ca1b2)
`TokenRepositoryImpl`에 `HttpClient`를 주입해서 기존 `clearTokens()`에 `httpClient.get().authProvider<BearerAuthProvider>()?.clearToken()` 구문을 추가했습니다.
위 커밋처럼 Impl에 `HttpClient`를 Lazy 주입하는 방법이 좋을까요? (Lazy 주입을 하는 이유는 `HttpClient` -> `TokenRepository` -> `HttpClient`로 참조하기 때문입니다.)

혹은 `HttpClient`를 Impl에 주입하지 않고, `NetworkModule`의 `HttpClient` 인스턴스를 정의하는 `provideHttpClient()` 내부에서 인터셉터를 추가해 로그아웃/탈퇴 요청이라면 `httpClient.get().authProvider<BearerAuthProvider>()?.clearToken()` 해당 구문을 추가하는 방식이 좋을까요? 
```
install(HttpSend) {
    intercept { request ->
        val response = execute(request)

        val isLogoutOrWithdraw = request.url.encodedPath in listOf(
            "/api/auth/logout",
            "/api/members/withdraw"
        )

        if (isLogoutOrWithdraw && response.response.status.isSuccess()) {
            authProvider<BearerAuthProvider>()?.clearToken()
        }

        response
    }
}
```

익성님 의견은 어떠신지 궁금합니다.