### PR TITLE
[fix] #161 ArchiveResult 화면별 Result 타입 분리

### DIFF
--- a/app/src/main/java/com/neki/android/app/main/MainScreen.kt
+++ b/app/src/main/java/com/neki/android/app/main/MainScreen.kt
@@ -33,7 +33,7 @@ import com.neki.android.core.ui.component.LoadingDialog
 import com.neki.android.core.ui.compose.collectWithLifecycle
 import com.neki.android.core.ui.toast.NekiToast
 import com.neki.android.feature.archive.api.ArchiveNavKey
-import com.neki.android.feature.archive.api.ArchiveResult
+import com.neki.android.feature.archive.api.PhotoUploadedResult
 import com.neki.android.feature.map.api.MapNavKey
 import com.neki.android.feature.mypage.api.MyPageNavKey
 import com.neki.android.feature.photo_upload.api.PhotoUploadNavKey
@@ -86,7 +86,7 @@ fun MainRoute(
             is MainSideEffect.NavigateToUploadAlbumWithGallery -> navigateToUploadAlbumWithGallery(sideEffect.uriStrings)
             is MainSideEffect.NavigateToUploadAlbumWithQRScan -> navigateToUploadAlbumWithQRScan(sideEffect.imageUrl)
             is MainSideEffect.ShowToast -> nekiToast.showToast(sideEffect.message)
-            MainSideEffect.RefreshArchive -> resultBus.sendResult<ArchiveResult>(result = ArchiveResult.PhotoUploaded)
+            MainSideEffect.RefreshArchive -> resultBus.sendResult(result = PhotoUploadedResult, allowDuplicate = false)
         }
     }
 

--- a/app/src/main/java/com/neki/android/app/navigation/keys/Keys.kt
+++ b/app/src/main/java/com/neki/android/app/navigation/keys/Keys.kt
@@ -7,7 +7,5 @@ import com.neki.android.feature.auth.api.AuthNavKey
 
 internal val START_AUTH_NAV_KEY = AuthNavKey.Splash
 internal val START_MAIN_NAV_KEY = ArchiveNavKey.Archive
-
-// TODO: 테스트용 - 반드시 원복할 것
-internal val START_ROOT_NAV_KEY = RootNavKey.Main
+internal val START_ROOT_NAV_KEY = RootNavKey.Auth(START_AUTH_NAV_KEY)
 internal val TOP_LEVEL_MAIN_NAV_KEYS = TopLevelNavItem.entries.map { it.navKey }

--- a/app/src/main/java/com/neki/android/app/navigation/keys/Keys.kt
+++ b/app/src/main/java/com/neki/android/app/navigation/keys/Keys.kt
@@ -7,5 +7,7 @@ import com.neki.android.feature.auth.api.AuthNavKey
 
 internal val START_AUTH_NAV_KEY = AuthNavKey.Splash
 internal val START_MAIN_NAV_KEY = ArchiveNavKey.Archive
-internal val START_ROOT_NAV_KEY = RootNavKey.Auth(START_AUTH_NAV_KEY)
+
+// TODO: 테스트용 - 반드시 원복할 것
+internal val START_ROOT_NAV_KEY = RootNavKey.Main
 internal val TOP_LEVEL_MAIN_NAV_KEYS = TopLevelNavItem.entries.map { it.navKey }

--- a/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/PhotoRepository.kt
+++ b/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/PhotoRepository.kt
@@ -25,6 +25,8 @@ interface PhotoRepository {
 
     suspend fun updateFavorite(photoId: Long, favorite: Boolean): Result<Unit>
 
+    suspend fun updateMemo(photoId: Long, memo: String): Result<Unit>
+
     suspend fun getPhotosPage(
         folderId: Long? = null,
         page: Int = 0,

--- a/core/data/src/main/java/com/neki/android/core/data/remote/api/PhotoService.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/api/PhotoService.kt
@@ -3,6 +3,7 @@ package com.neki.android.core.data.remote.api
 import com.neki.android.core.data.remote.model.request.DeletePhotoRequest
 import com.neki.android.core.data.remote.model.request.RegisterPhotoRequest
 import com.neki.android.core.data.remote.model.request.UpdateFavoriteRequest
+import com.neki.android.core.data.remote.model.request.UpdateMemoRequest
 import com.neki.android.core.data.remote.model.response.BasicNullableResponse
 import com.neki.android.core.data.remote.model.response.BasicResponse
 import com.neki.android.core.data.remote.model.response.FavoriteSummaryResponse
@@ -15,6 +16,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.patch
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import javax.inject.Inject
 
@@ -50,6 +52,13 @@ class PhotoService @Inject constructor(
     suspend fun updateFavorite(photoId: Long, favorite: Boolean): BasicNullableResponse<Unit> {
         return client.patch("/api/photos/$photoId/favorite") {
             setBody(UpdateFavoriteRequest(favorite))
+        }.body()
+    }
+
+    // 메모 수정
+    suspend fun updateMemo(photoId: Long, memo: String): BasicNullableResponse<Unit> {
+        return client.put("/api/photos/$photoId") {
+            setBody(UpdateMemoRequest(memo))
         }.body()
     }
 

--- a/core/data/src/main/java/com/neki/android/core/data/remote/model/request/UpdateMemoRequest.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/model/request/UpdateMemoRequest.kt
@@ -1,0 +1,9 @@
+package com.neki.android.core.data.remote.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateMemoRequest(
+    @SerialName("memo") val memo: String,
+)

--- a/core/data/src/main/java/com/neki/android/core/data/remote/model/response/PhotoResponse.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/model/response/PhotoResponse.kt
@@ -20,6 +20,7 @@ data class PhotoResponse(
         @SerialName("width") val width: Int? = null,
         @SerialName("height") val height: Int? = null,
         @SerialName("createdAt") val createdAt: String,
+        @SerialName("memo") val memo: String? = null, // TODO: API에 memo 필드 추가 후 nullable 제거
     ) {
         internal fun toModel() = Photo(
             id = photoId,
@@ -29,6 +30,7 @@ data class PhotoResponse(
             height = height,
             date = createdAt.toFormattedDate(),
             contentType = ContentType.fromString(contentType),
+            memo = memo.orEmpty(),
         )
     }
 

--- a/core/data/src/main/java/com/neki/android/core/data/remote/model/response/PhotoResponse.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/model/response/PhotoResponse.kt
@@ -20,7 +20,7 @@ data class PhotoResponse(
         @SerialName("width") val width: Int? = null,
         @SerialName("height") val height: Int? = null,
         @SerialName("createdAt") val createdAt: String,
-        @SerialName("memo") val memo: String? = null, // TODO: API에 memo 필드 추가 후 nullable 제거
+        @SerialName("memo") val memo: String? = null,
     ) {
         internal fun toModel() = Photo(
             id = photoId,

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/PhotoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/PhotoRepositoryImpl.kt
@@ -65,6 +65,10 @@ class PhotoRepositoryImpl @Inject constructor(
         photoService.updateFavorite(photoId, favorite)
     }
 
+    override suspend fun updateMemo(photoId: Long, memo: String): Result<Unit> = runSuspendCatching {
+        photoService.updateMemo(photoId, memo)
+    }
+
     override suspend fun getPhotosPage(
         folderId: Long?,
         page: Int,

--- a/core/designsystem/src/main/res/drawable/icon_memo.xml
+++ b/core/designsystem/src/main/res/drawable/icon_memo.xml
@@ -1,0 +1,23 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:viewportWidth="28"
+    android:viewportHeight="28">
+  <path
+      android:pathData="M11.698,22.845H4.45C3.649,22.845 3,22.196 3,21.396V11.849C3,11.464 3.153,11.095 3.425,10.824L9.824,4.425C10.095,4.153 10.464,4 10.849,4H20.396C21.196,4 21.845,4.649 21.845,5.45V11.248"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.93285"
+      android:fillColor="#00000000"
+      android:strokeColor="#4F525F"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M3,11.731H8.315C9.116,11.731 9.765,11.082 9.765,10.282V4"
+      android:strokeWidth="1.93285"
+      android:fillColor="#00000000"
+      android:strokeColor="#4F525F"/>
+  <path
+      android:pathData="M20.699,14.347L15.035,20.012C14.91,20.137 14.822,20.294 14.78,20.465L14.37,22.141C14.196,22.85 14.84,23.487 15.547,23.308L17.204,22.886C17.373,22.843 17.527,22.755 17.649,22.632L23.317,16.965C23.694,16.588 23.694,15.976 23.317,15.598L22.066,14.347C21.689,13.97 21.077,13.97 20.699,14.347Z"
+      android:strokeWidth="1.93285"
+      android:fillColor="#00000000"
+      android:strokeColor="#4F525F"/>
+</vector>

--- a/core/model/src/main/java/com/neki/android/core/model/Photo.kt
+++ b/core/model/src/main/java/com/neki/android/core/model/Photo.kt
@@ -13,4 +13,5 @@ data class Photo(
     val width: Int? = null,
     val height: Int? = null,
     val contentType: ContentType = ContentType.JPEG,
+    val memo: String = "",
 )

--- a/feature/archive/api/src/main/kotlin/com/neki/android/feature/archive/api/ArchiveResult.kt
+++ b/feature/archive/api/src/main/kotlin/com/neki/android/feature/archive/api/ArchiveResult.kt
@@ -8,4 +8,6 @@ sealed interface ArchiveResult {
     data class FavoriteChanged(val photoId: Long, val isFavorite: Boolean) : ArchiveResult
 
     data object PhotoUploaded : ArchiveResult
+
+    data object AlbumChanged : ArchiveResult
 }

--- a/feature/archive/api/src/main/kotlin/com/neki/android/feature/archive/api/ArchiveResult.kt
+++ b/feature/archive/api/src/main/kotlin/com/neki/android/feature/archive/api/ArchiveResult.kt
@@ -1,13 +1,13 @@
 package com.neki.android.feature.archive.api
 
-sealed interface ArchiveResult {
-    data class PhotoDeleted(val photoId: List<Long>) : ArchiveResult {
-        constructor(photoId: Long) : this(listOf(photoId))
-    }
+sealed interface ArchiveResult
 
-    data class FavoriteChanged(val photoId: Long, val isFavorite: Boolean) : ArchiveResult
+data object PhotoDetailResult : ArchiveResult
 
-    data object PhotoUploaded : ArchiveResult
+data object AlbumDetailResult : ArchiveResult
 
-    data object AlbumChanged : ArchiveResult
-}
+data object AllPhotoResult : ArchiveResult
+
+data object AllAlbumResult : ArchiveResult
+
+data object PhotoUploadedResult : ArchiveResult

--- a/feature/archive/impl/build.gradle.kts
+++ b/feature/archive/impl/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.paging.compose)
+    implementation(libs.zoomable)
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumContract.kt
@@ -2,6 +2,7 @@ package com.neki.android.feature.archive.impl.album
 
 import androidx.compose.foundation.text.input.TextFieldState
 import com.neki.android.core.model.AlbumPreview
+import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.impl.model.SelectMode
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -53,6 +54,9 @@ sealed interface AllAlbumIntent {
     data object DismissDeleteAlbumBottomSheet : AllAlbumIntent
     data class SelectDeleteOption(val option: AlbumDeleteOption) : AllAlbumIntent
     data object ClickDeleteConfirmButton : AllAlbumIntent
+
+    // Result Intent
+    data object RefreshAlbums : AllAlbumIntent
 }
 
 sealed interface AllAlbumSideEffect {
@@ -60,4 +64,5 @@ sealed interface AllAlbumSideEffect {
     data class NavigateToFavoriteAlbum(val albumId: Long) : AllAlbumSideEffect
     data class NavigateToAlbumDetail(val albumId: Long, val title: String) : AllAlbumSideEffect
     data class ShowToastMessage(val message: String) : AllAlbumSideEffect
+    data class NotifyArchiveResult(val result: ArchiveResult) : AllAlbumSideEffect
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumContract.kt
@@ -2,7 +2,6 @@ package com.neki.android.feature.archive.impl.album
 
 import androidx.compose.foundation.text.input.TextFieldState
 import com.neki.android.core.model.AlbumPreview
-import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.impl.model.SelectMode
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -64,5 +63,5 @@ sealed interface AllAlbumSideEffect {
     data class NavigateToFavoriteAlbum(val albumId: Long) : AllAlbumSideEffect
     data class NavigateToAlbumDetail(val albumId: Long, val title: String) : AllAlbumSideEffect
     data class ShowToastMessage(val message: String) : AllAlbumSideEffect
-    data class NotifyArchiveResult(val result: ArchiveResult) : AllAlbumSideEffect
+    data object NotifyResult : AllAlbumSideEffect
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumScreen.kt
@@ -21,6 +21,7 @@ import com.neki.android.core.designsystem.DevicePreview
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.model.AlbumPreview
 import com.neki.android.core.navigation.result.LocalResultEventBus
+import com.neki.android.feature.archive.api.AllAlbumResult
 import com.neki.android.core.ui.component.AlbumRowComponent
 import com.neki.android.core.ui.component.DoubleButtonOptionBottomSheet
 import com.neki.android.core.ui.component.FavoriteAlbumRowComponent
@@ -52,8 +53,8 @@ internal fun AllAlbumRoute(
             is AllAlbumSideEffect.ShowToastMessage -> {
                 nekiToast.showToast(text = sideEffect.message)
             }
-            is AllAlbumSideEffect.NotifyArchiveResult -> {
-                resultEventBus.sendResult(result = sideEffect.result, allowDuplicate = false)
+            AllAlbumSideEffect.NotifyResult -> {
+                resultEventBus.sendResult(result = AllAlbumResult, allowDuplicate = false)
             }
         }
     }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumScreen.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.neki.android.core.designsystem.DevicePreview
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.model.AlbumPreview
+import com.neki.android.core.navigation.result.LocalResultEventBus
 import com.neki.android.core.ui.component.AlbumRowComponent
 import com.neki.android.core.ui.component.DoubleButtonOptionBottomSheet
 import com.neki.android.core.ui.component.FavoriteAlbumRowComponent
@@ -41,6 +42,7 @@ internal fun AllAlbumRoute(
     val uiState by viewModel.store.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     val nekiToast = remember { NekiToast(context) }
+    val resultEventBus = LocalResultEventBus.current
 
     viewModel.store.sideEffects.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
@@ -49,6 +51,9 @@ internal fun AllAlbumRoute(
             is AllAlbumSideEffect.NavigateToAlbumDetail -> navigateToAlbumDetail(sideEffect.albumId, sideEffect.title)
             is AllAlbumSideEffect.ShowToastMessage -> {
                 nekiToast.showToast(text = sideEffect.message)
+            }
+            is AllAlbumSideEffect.NotifyArchiveResult -> {
+                resultEventBus.sendResult(result = sideEffect.result, allowDuplicate = false)
             }
         }
     }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumViewModel.kt
@@ -182,6 +182,7 @@ class AllAlbumViewModel @Inject constructor(
                 .onSuccess {
                     fetchFolders(reduce)
                     postSideEffect(AllAlbumSideEffect.ShowToastMessage("새로운 앨범을 추가했어요"))
+                    postSideEffect(AllAlbumSideEffect.NotifyArchiveResult(ArchiveResult.AlbumChanged))
                 }
                 .onFailure { e ->
                     postSideEffect(AllAlbumSideEffect.ShowToastMessage("앨범 추가에 실패했어요"))

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumViewModel.kt
@@ -7,6 +7,7 @@ import com.neki.android.core.dataapi.repository.PhotoRepository
 import com.neki.android.core.model.AlbumPreview
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
+import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.impl.model.SelectMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
@@ -76,6 +77,9 @@ class AllAlbumViewModel @Inject constructor(
             AllAlbumIntent.DismissDeleteAlbumBottomSheet -> reduce { copy(isShowDeleteAlbumBottomSheet = false) }
             is AllAlbumIntent.SelectDeleteOption -> reduce { copy(selectedDeleteOption = intent.option) }
             AllAlbumIntent.ClickDeleteConfirmButton -> handleDeleteConfirm(state, reduce, postSideEffect)
+
+            // Result Intent
+            AllAlbumIntent.RefreshAlbums -> fetchInitialData(reduce)
         }
     }
 
@@ -200,6 +204,7 @@ class AllAlbumViewModel @Inject constructor(
                 .onSuccess {
                     fetchFolders(reduce)
                     postSideEffect(AllAlbumSideEffect.ShowToastMessage("앨범을 삭제했어요"))
+                    postSideEffect(AllAlbumSideEffect.NotifyArchiveResult(ArchiveResult.AlbumChanged))
                 }
                 .onFailure { e ->
                     Timber.e(e, "사진 삭제 실패")

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumViewModel.kt
@@ -7,7 +7,6 @@ import com.neki.android.core.dataapi.repository.PhotoRepository
 import com.neki.android.core.model.AlbumPreview
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
-import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.impl.model.SelectMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
@@ -182,7 +181,7 @@ class AllAlbumViewModel @Inject constructor(
                 .onSuccess {
                     fetchFolders(reduce)
                     postSideEffect(AllAlbumSideEffect.ShowToastMessage("새로운 앨범을 추가했어요"))
-                    postSideEffect(AllAlbumSideEffect.NotifyArchiveResult(ArchiveResult.AlbumChanged))
+                    postSideEffect(AllAlbumSideEffect.NotifyResult)
                 }
                 .onFailure { e ->
                     postSideEffect(AllAlbumSideEffect.ShowToastMessage("앨범 추가에 실패했어요"))
@@ -205,7 +204,7 @@ class AllAlbumViewModel @Inject constructor(
                 .onSuccess {
                     fetchFolders(reduce)
                     postSideEffect(AllAlbumSideEffect.ShowToastMessage("앨범을 삭제했어요"))
-                    postSideEffect(AllAlbumSideEffect.NotifyArchiveResult(ArchiveResult.AlbumChanged))
+                    postSideEffect(AllAlbumSideEffect.NotifyResult)
                 }
                 .onFailure { e ->
                     Timber.e(e, "사진 삭제 실패")

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailContract.kt
@@ -3,7 +3,6 @@ package com.neki.android.feature.archive.impl.album_detail
 import android.net.Uri
 import androidx.compose.foundation.text.input.TextFieldState
 import com.neki.android.core.model.Photo
-import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.impl.model.SelectMode
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -72,9 +71,8 @@ sealed interface AlbumDetailIntent {
     data object ClickRenameBottomSheetConfirmButton : AlbumDetailIntent
 
     // Result Intent
-    data class PhotoDeleted(val photoIds: List<Long>) : AlbumDetailIntent
+    data object RefreshPhotos : AlbumDetailIntent
     data class ClickFavoriteIcon(val photo: Photo) : AlbumDetailIntent
-    data class FavoriteChanged(val photoId: Long, val isFavorite: Boolean) : AlbumDetailIntent
 }
 
 sealed interface AlbumDetailSideEffect {
@@ -84,5 +82,5 @@ sealed interface AlbumDetailSideEffect {
     data class DownloadImages(val imageUrls: List<String>) : AlbumDetailSideEffect
     data object OpenGallery : AlbumDetailSideEffect
     data object RefreshPhotos : AlbumDetailSideEffect
-    data class NotifyArchiveResult(val result: ArchiveResult) : AlbumDetailSideEffect
+    data object NotifyResult : AlbumDetailSideEffect
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailContract.kt
@@ -3,6 +3,7 @@ package com.neki.android.feature.archive.impl.album_detail
 import android.net.Uri
 import androidx.compose.foundation.text.input.TextFieldState
 import com.neki.android.core.model.Photo
+import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.impl.model.SelectMode
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -83,4 +84,5 @@ sealed interface AlbumDetailSideEffect {
     data class DownloadImages(val imageUrls: List<String>) : AlbumDetailSideEffect
     data object OpenGallery : AlbumDetailSideEffect
     data object RefreshPhotos : AlbumDetailSideEffect
+    data class NotifyArchiveResult(val result: ArchiveResult) : AlbumDetailSideEffect
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailScreen.kt
@@ -37,6 +37,7 @@ import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.model.Photo
 import com.neki.android.core.model.SortOrder
 import com.neki.android.core.navigation.result.LocalResultEventBus
+import com.neki.android.feature.archive.api.AlbumDetailResult
 import com.neki.android.core.ui.component.DoubleButtonOptionBottomSheet
 import com.neki.android.feature.archive.api.ArchiveNavKey
 import com.neki.android.core.ui.component.LoadingDialog
@@ -112,8 +113,8 @@ internal fun AlbumDetailRoute(
             AlbumDetailSideEffect.OpenGallery -> photoPicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
             AlbumDetailSideEffect.RefreshPhotos -> pagingItems.refresh()
 
-            is AlbumDetailSideEffect.NotifyArchiveResult -> {
-                resultEventBus.sendResult(result = sideEffect.result, allowDuplicate = false)
+            AlbumDetailSideEffect.NotifyResult -> {
+                resultEventBus.sendResult(result = AlbumDetailResult, allowDuplicate = false)
             }
         }
     }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailScreen.kt
@@ -36,6 +36,7 @@ import androidx.paging.compose.itemKey
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.model.Photo
 import com.neki.android.core.model.SortOrder
+import com.neki.android.core.navigation.result.LocalResultEventBus
 import com.neki.android.core.ui.component.DoubleButtonOptionBottomSheet
 import com.neki.android.feature.archive.api.ArchiveNavKey
 import com.neki.android.core.ui.component.LoadingDialog
@@ -69,6 +70,7 @@ internal fun AlbumDetailRoute(
     val pagingItems = viewModel.photoPagingData.collectAsLazyPagingItems()
     val context = LocalContext.current
     val nekiToast = remember { NekiToast(context) }
+    val resultEventBus = LocalResultEventBus.current
     val photoPicker = rememberLauncherForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(10)) { uris ->
         if (uris.isNotEmpty()) {
             viewModel.store.onIntent(AlbumDetailIntent.SelectGalleryImage(uris))
@@ -109,6 +111,10 @@ internal fun AlbumDetailRoute(
 
             AlbumDetailSideEffect.OpenGallery -> photoPicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
             AlbumDetailSideEffect.RefreshPhotos -> pagingItems.refresh()
+
+            is AlbumDetailSideEffect.NotifyArchiveResult -> {
+                resultEventBus.sendResult(result = sideEffect.result, allowDuplicate = false)
+            }
         }
     }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailViewModel.kt
@@ -14,7 +14,6 @@ import com.neki.android.core.domain.usecase.UploadMultiplePhotoUseCase
 import com.neki.android.core.model.Photo
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
-import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.impl.model.SelectMode
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -144,8 +143,10 @@ class AlbumDetailViewModel @AssistedInject constructor(
             is AlbumDetailIntent.SelectGalleryImage -> uploadMultipleImages(intent.uris, reduce, postSideEffect)
 
             // Result Intent
-            is AlbumDetailIntent.PhotoDeleted -> {
-                deletedPhotoIds.update { it + intent.photoIds.toSet() }
+            AlbumDetailIntent.RefreshPhotos -> {
+                deletedPhotoIds.value = emptySet()
+                updatedFavorites.value = emptyMap()
+                postSideEffect(AlbumDetailSideEffect.RefreshPhotos)
             }
 
             is AlbumDetailIntent.ClickFavoriteIcon -> {
@@ -159,10 +160,6 @@ class AlbumDetailViewModel @AssistedInject constructor(
                             updatedFavorites.update { it + (photo.id to photo.isFavorite) }
                         }
                 }
-            }
-
-            is AlbumDetailIntent.FavoriteChanged -> {
-                updatedFavorites.update { it + (intent.photoId to intent.isFavorite) }
             }
 
             AlbumDetailIntent.DismissRenameBottomSheet -> reduce {
@@ -197,7 +194,7 @@ class AlbumDetailViewModel @AssistedInject constructor(
                     )
                 }
                 postSideEffect(AlbumDetailSideEffect.ShowToastMessage("앨범 이름을 변경했어요"))
-                postSideEffect(AlbumDetailSideEffect.NotifyArchiveResult(ArchiveResult.AlbumChanged))
+                postSideEffect(AlbumDetailSideEffect.NotifyResult)
             }.onFailure { e ->
                 Timber.e(e)
                 reduce { copy(isLoading = false) }
@@ -222,7 +219,7 @@ class AlbumDetailViewModel @AssistedInject constructor(
                 reduce { copy(isLoading = false) }
                 postSideEffect(AlbumDetailSideEffect.RefreshPhotos)
                 postSideEffect(AlbumDetailSideEffect.ShowToastMessage("새로운 사진을 추가했어요"))
-                postSideEffect(AlbumDetailSideEffect.NotifyArchiveResult(ArchiveResult.PhotoUploaded))
+                postSideEffect(AlbumDetailSideEffect.NotifyResult)
             }.onFailure { e ->
                 Timber.e(e)
                 postSideEffect(AlbumDetailSideEffect.ShowToastMessage("이미지 업로드에 실패했어요"))
@@ -325,7 +322,7 @@ class AlbumDetailViewModel @AssistedInject constructor(
                         )
                     }
                     postSideEffect(AlbumDetailSideEffect.ShowToastMessage("사진을 삭제했어요"))
-                    postSideEffect(AlbumDetailSideEffect.NotifyArchiveResult(ArchiveResult.PhotoDeleted(selectedPhotoIds)))
+                    postSideEffect(AlbumDetailSideEffect.NotifyResult)
                 }
                 .onFailure { e ->
                     Timber.e(e)
@@ -368,7 +365,7 @@ class AlbumDetailViewModel @AssistedInject constructor(
                         )
                     }
                     postSideEffect(AlbumDetailSideEffect.ShowToastMessage("사진을 삭제했어요"))
-                    postSideEffect(AlbumDetailSideEffect.NotifyArchiveResult(ArchiveResult.PhotoDeleted(selectedPhotoIds)))
+                    postSideEffect(AlbumDetailSideEffect.NotifyResult)
                 }
                 .onFailure { e ->
                     Timber.e(e)

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailViewModel.kt
@@ -14,6 +14,7 @@ import com.neki.android.core.domain.usecase.UploadMultiplePhotoUseCase
 import com.neki.android.core.model.Photo
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
+import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.impl.model.SelectMode
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -196,6 +197,7 @@ class AlbumDetailViewModel @AssistedInject constructor(
                     )
                 }
                 postSideEffect(AlbumDetailSideEffect.ShowToastMessage("앨범 이름을 변경했어요"))
+                postSideEffect(AlbumDetailSideEffect.NotifyArchiveResult(ArchiveResult.AlbumChanged))
             }.onFailure { e ->
                 Timber.e(e)
                 reduce { copy(isLoading = false) }
@@ -220,6 +222,7 @@ class AlbumDetailViewModel @AssistedInject constructor(
                 reduce { copy(isLoading = false) }
                 postSideEffect(AlbumDetailSideEffect.RefreshPhotos)
                 postSideEffect(AlbumDetailSideEffect.ShowToastMessage("새로운 사진을 추가했어요"))
+                postSideEffect(AlbumDetailSideEffect.NotifyArchiveResult(ArchiveResult.PhotoUploaded))
             }.onFailure { e ->
                 Timber.e(e)
                 postSideEffect(AlbumDetailSideEffect.ShowToastMessage("이미지 업로드에 실패했어요"))
@@ -322,6 +325,7 @@ class AlbumDetailViewModel @AssistedInject constructor(
                         )
                     }
                     postSideEffect(AlbumDetailSideEffect.ShowToastMessage("사진을 삭제했어요"))
+                    postSideEffect(AlbumDetailSideEffect.NotifyArchiveResult(ArchiveResult.PhotoDeleted(selectedPhotoIds)))
                 }
                 .onFailure { e ->
                     Timber.e(e)
@@ -364,6 +368,7 @@ class AlbumDetailViewModel @AssistedInject constructor(
                         )
                     }
                     postSideEffect(AlbumDetailSideEffect.ShowToastMessage("사진을 삭제했어요"))
+                    postSideEffect(AlbumDetailSideEffect.NotifyArchiveResult(ArchiveResult.PhotoDeleted(selectedPhotoIds)))
                 }
                 .onFailure { e ->
                     Timber.e(e)

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainContract.kt
@@ -18,7 +18,7 @@ data class ArchiveMainState(
 
 sealed interface ArchiveMainIntent {
     data object EnterArchiveMainScreen : ArchiveMainIntent
-    data object RefreshArchiveMainPhotos : ArchiveMainIntent
+    data object RefreshArchiveMain : ArchiveMainIntent
     data object ClickScreen : ArchiveMainIntent
     data object ClickGoToTopButton : ArchiveMainIntent
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
@@ -45,7 +45,13 @@ class ArchiveMainViewModel @Inject constructor(
         if (intent != ArchiveMainIntent.EnterArchiveMainScreen) reduce { copy(isFirstEntered = false) }
         when (intent) {
             ArchiveMainIntent.EnterArchiveMainScreen -> fetchInitialData(reduce)
-            ArchiveMainIntent.RefreshArchiveMainPhotos -> viewModelScope.launch { fetchPhotos(reduce) }
+            ArchiveMainIntent.RefreshArchiveMain -> viewModelScope.launch {
+                awaitAll(
+                    async { fetchFavoriteSummary(reduce) },
+                    async { fetchPhotos(reduce) },
+                    async { fetchFolders(reduce) },
+                )
+            }
             ArchiveMainIntent.ClickScreen -> reduce { copy(isFirstEntered = false) }
             ArchiveMainIntent.ClickGoToTopButton -> postSideEffect(ArchiveMainSideEffect.ScrollToTop)
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
@@ -91,6 +91,7 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
 
         ResultEffect<PhotoDetailResult>(resultBus) {
             viewModel.store.onIntent(AllPhotoIntent.RefreshPhotos)
+            resultBus.sendResult(result = AllPhotoResult, allowDuplicate = false)
         }
 
         AllPhotoRoute(
@@ -106,6 +107,7 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
 
         ResultEffect<AlbumDetailResult>(resultBus) {
             viewModel.store.onIntent(AllAlbumIntent.RefreshAlbums)
+            resultBus.sendResult(result = AllAlbumResult, allowDuplicate = false)
         }
 
         AllAlbumRoute(
@@ -128,6 +130,7 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
 
         ResultEffect<PhotoDetailResult>(resultBus) {
             viewModel.store.onIntent(AlbumDetailIntent.RefreshPhotos)
+            resultBus.sendResult(result = AlbumDetailResult, allowDuplicate = false)
         }
 
         AlbumDetailRoute(

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
@@ -11,8 +11,8 @@ import com.neki.android.feature.archive.api.AlbumDetailResult
 import com.neki.android.feature.archive.api.AllAlbumResult
 import com.neki.android.feature.archive.api.AllPhotoResult
 import com.neki.android.feature.archive.api.ArchiveNavKey
+import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.api.PhotoDetailResult
-import com.neki.android.feature.archive.api.PhotoUploadedResult
 import com.neki.android.feature.archive.api.navigateToAlbumDetail
 import com.neki.android.feature.archive.api.navigateToAllAlbum
 import com.neki.android.feature.archive.api.navigateToAllPhoto
@@ -54,19 +54,7 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
         val resultBus = LocalResultEventBus.current
         val viewModel = hiltViewModel<ArchiveMainViewModel>()
 
-        ResultEffect<PhotoDetailResult>(resultBus) {
-            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
-        }
-        ResultEffect<AlbumDetailResult>(resultBus) {
-            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
-        }
-        ResultEffect<AllPhotoResult>(resultBus) {
-            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
-        }
-        ResultEffect<AllAlbumResult>(resultBus) {
-            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
-        }
-        ResultEffect<PhotoUploadedResult>(resultBus) {
+        ResultEffect<ArchiveResult>(resultBus) {
             viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
         }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
@@ -11,8 +11,8 @@ import com.neki.android.feature.archive.api.AlbumDetailResult
 import com.neki.android.feature.archive.api.AllAlbumResult
 import com.neki.android.feature.archive.api.AllPhotoResult
 import com.neki.android.feature.archive.api.ArchiveNavKey
-import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.api.PhotoDetailResult
+import com.neki.android.feature.archive.api.PhotoUploadedResult
 import com.neki.android.feature.archive.api.navigateToAlbumDetail
 import com.neki.android.feature.archive.api.navigateToAllAlbum
 import com.neki.android.feature.archive.api.navigateToAllPhoto
@@ -54,7 +54,19 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
         val resultBus = LocalResultEventBus.current
         val viewModel = hiltViewModel<ArchiveMainViewModel>()
 
-        ResultEffect<ArchiveResult>(resultBus) {
+        ResultEffect<PhotoDetailResult>(resultBus) {
+            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
+        }
+        ResultEffect<AlbumDetailResult>(resultBus) {
+            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
+        }
+        ResultEffect<AllPhotoResult>(resultBus) {
+            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
+        }
+        ResultEffect<AllAlbumResult>(resultBus) {
+            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
+        }
+        ResultEffect<PhotoUploadedResult>(resultBus) {
             viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
         }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
@@ -13,7 +13,9 @@ import com.neki.android.feature.archive.api.navigateToAlbumDetail
 import com.neki.android.feature.archive.api.navigateToAllAlbum
 import com.neki.android.feature.archive.api.navigateToAllPhoto
 import com.neki.android.feature.archive.api.navigateToPhotoDetail
+import com.neki.android.feature.archive.impl.album.AllAlbumIntent
 import com.neki.android.feature.archive.impl.album.AllAlbumRoute
+import com.neki.android.feature.archive.impl.album.AllAlbumViewModel
 import com.neki.android.feature.archive.impl.album_detail.AlbumDetailIntent
 import com.neki.android.feature.archive.impl.album_detail.AlbumDetailRoute
 import com.neki.android.feature.archive.impl.album_detail.AlbumDetailViewModel
@@ -49,7 +51,8 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
         val viewModel = hiltViewModel<ArchiveMainViewModel>()
         ResultEffect<ArchiveResult>(resultBus) { result ->
             when (result) {
-                is ArchiveResult.FavoriteChanged, is ArchiveResult.PhotoDeleted, ArchiveResult.PhotoUploaded ->
+                is ArchiveResult.FavoriteChanged, is ArchiveResult.PhotoDeleted,
+                ArchiveResult.PhotoUploaded, ArchiveResult.AlbumChanged ->
                     viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMainPhotos)
             }
         }
@@ -95,7 +98,19 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
     }
 
     entry<ArchiveNavKey.AllAlbum> {
+        val resultBus = LocalResultEventBus.current
+        val viewModel = hiltViewModel<AllAlbumViewModel>()
+
+        ResultEffect<ArchiveResult>(resultBus) { result ->
+            when (result) {
+                is ArchiveResult.FavoriteChanged, is ArchiveResult.PhotoDeleted,
+                ArchiveResult.PhotoUploaded, ArchiveResult.AlbumChanged ->
+                    viewModel.store.onIntent(AllAlbumIntent.RefreshAlbums)
+            }
+        }
+
         AllAlbumRoute(
+            viewModel = viewModel,
             navigateBack = navigator::goBack,
             navigateToFavoriteAlbum = { id ->
                 navigator.navigateToAlbumDetail(id = id, isFavorite = true)

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
@@ -53,7 +53,7 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
             when (result) {
                 is ArchiveResult.FavoriteChanged, is ArchiveResult.PhotoDeleted,
                 ArchiveResult.PhotoUploaded, ArchiveResult.AlbumChanged ->
-                    viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMainPhotos)
+                    viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
             }
         }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
@@ -86,6 +86,10 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
                     viewModel.store.onIntent(AllPhotoIntent.PhotoDeleted(result.photoId))
                 }
 
+                ArchiveResult.PhotoUploaded -> {
+                    viewModel.store.onIntent(AllPhotoIntent.RefreshPhotos)
+                }
+
                 else -> {}
             }
         }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/navigation/ArchiveEntryProvider.kt
@@ -7,8 +7,12 @@ import com.neki.android.core.navigation.main.EntryProviderInstaller
 import com.neki.android.core.navigation.main.MainNavigator
 import com.neki.android.core.navigation.result.LocalResultEventBus
 import com.neki.android.core.navigation.result.ResultEffect
+import com.neki.android.feature.archive.api.AlbumDetailResult
+import com.neki.android.feature.archive.api.AllAlbumResult
+import com.neki.android.feature.archive.api.AllPhotoResult
 import com.neki.android.feature.archive.api.ArchiveNavKey
-import com.neki.android.feature.archive.api.ArchiveResult
+import com.neki.android.feature.archive.api.PhotoDetailResult
+import com.neki.android.feature.archive.api.PhotoUploadedResult
 import com.neki.android.feature.archive.api.navigateToAlbumDetail
 import com.neki.android.feature.archive.api.navigateToAllAlbum
 import com.neki.android.feature.archive.api.navigateToAllPhoto
@@ -49,12 +53,21 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
     entry<ArchiveNavKey.Archive> {
         val resultBus = LocalResultEventBus.current
         val viewModel = hiltViewModel<ArchiveMainViewModel>()
-        ResultEffect<ArchiveResult>(resultBus) { result ->
-            when (result) {
-                is ArchiveResult.FavoriteChanged, is ArchiveResult.PhotoDeleted,
-                ArchiveResult.PhotoUploaded, ArchiveResult.AlbumChanged ->
-                    viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
-            }
+
+        ResultEffect<PhotoDetailResult>(resultBus) {
+            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
+        }
+        ResultEffect<AlbumDetailResult>(resultBus) {
+            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
+        }
+        ResultEffect<AllPhotoResult>(resultBus) {
+            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
+        }
+        ResultEffect<AllAlbumResult>(resultBus) {
+            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
+        }
+        ResultEffect<PhotoUploadedResult>(resultBus) {
+            viewModel.store.onIntent(ArchiveMainIntent.RefreshArchiveMain)
         }
 
         ArchiveMainRoute(
@@ -76,22 +89,8 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
         val resultBus = LocalResultEventBus.current
         val viewModel = hiltViewModel<AllPhotoViewModel>()
 
-        ResultEffect<ArchiveResult>(resultBus) { result ->
-            when (result) {
-                is ArchiveResult.FavoriteChanged -> {
-                    viewModel.store.onIntent(AllPhotoIntent.FavoriteChanged(result.photoId, result.isFavorite))
-                }
-
-                is ArchiveResult.PhotoDeleted -> {
-                    viewModel.store.onIntent(AllPhotoIntent.PhotoDeleted(result.photoId))
-                }
-
-                ArchiveResult.PhotoUploaded -> {
-                    viewModel.store.onIntent(AllPhotoIntent.RefreshPhotos)
-                }
-
-                else -> {}
-            }
+        ResultEffect<PhotoDetailResult>(resultBus) {
+            viewModel.store.onIntent(AllPhotoIntent.RefreshPhotos)
         }
 
         AllPhotoRoute(
@@ -105,12 +104,8 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
         val resultBus = LocalResultEventBus.current
         val viewModel = hiltViewModel<AllAlbumViewModel>()
 
-        ResultEffect<ArchiveResult>(resultBus) { result ->
-            when (result) {
-                is ArchiveResult.FavoriteChanged, is ArchiveResult.PhotoDeleted,
-                ArchiveResult.PhotoUploaded, ArchiveResult.AlbumChanged ->
-                    viewModel.store.onIntent(AllAlbumIntent.RefreshAlbums)
-            }
+        ResultEffect<AlbumDetailResult>(resultBus) {
+            viewModel.store.onIntent(AllAlbumIntent.RefreshAlbums)
         }
 
         AllAlbumRoute(
@@ -131,18 +126,8 @@ private fun EntryProviderScope<NavKey>.archiveEntry(navigator: MainNavigator) {
             creationCallback = { factory -> factory.create(key.albumId, key.title, key.isFavorite) },
         )
 
-        ResultEffect<ArchiveResult>(resultBus) { result ->
-            when (result) {
-                is ArchiveResult.FavoriteChanged -> {
-                    viewModel.store.onIntent(AlbumDetailIntent.FavoriteChanged(result.photoId, result.isFavorite))
-                }
-
-                is ArchiveResult.PhotoDeleted -> {
-                    viewModel.store.onIntent(AlbumDetailIntent.PhotoDeleted(result.photoId))
-                }
-
-                else -> {}
-            }
+        ResultEffect<PhotoDetailResult>(resultBus) {
+            viewModel.store.onIntent(AlbumDetailIntent.RefreshPhotos)
         }
 
         AlbumDetailRoute(

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoContract.kt
@@ -1,6 +1,7 @@
 package com.neki.android.feature.archive.impl.photo
 
 import com.neki.android.core.model.Photo
+import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.impl.model.SelectMode
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -55,4 +56,5 @@ sealed interface AllPhotoSideEffect {
     data class NavigateToPhotoDetail(val photo: Photo, val index: Int) : AllPhotoSideEffect
     data class ShowToastMessage(val message: String) : AllPhotoSideEffect
     data class DownloadImages(val imageUrls: List<String>) : AllPhotoSideEffect
+    data class NotifyArchiveResult(val result: ArchiveResult) : AllPhotoSideEffect
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoContract.kt
@@ -1,7 +1,6 @@
 package com.neki.android.feature.archive.impl.photo
 
 import com.neki.android.core.model.Photo
-import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.impl.model.SelectMode
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -45,9 +44,7 @@ sealed interface AllPhotoIntent {
     data object ClickDeleteDialogConfirmButton : AllPhotoIntent
 
     // Result Intent
-    data class PhotoDeleted(val photoIds: List<Long>) : AllPhotoIntent
     data class ClickFavoriteIcon(val photo: Photo) : AllPhotoIntent
-    data class FavoriteChanged(val photoId: Long, val isFavorite: Boolean) : AllPhotoIntent
     data object RefreshPhotos : AllPhotoIntent
 }
 
@@ -57,6 +54,6 @@ sealed interface AllPhotoSideEffect {
     data class NavigateToPhotoDetail(val photo: Photo, val index: Int) : AllPhotoSideEffect
     data class ShowToastMessage(val message: String) : AllPhotoSideEffect
     data class DownloadImages(val imageUrls: List<String>) : AllPhotoSideEffect
-    data class NotifyArchiveResult(val result: ArchiveResult) : AllPhotoSideEffect
+    data object NotifyResult : AllPhotoSideEffect
     data object RefreshPhotos : AllPhotoSideEffect
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoContract.kt
@@ -48,6 +48,7 @@ sealed interface AllPhotoIntent {
     data class PhotoDeleted(val photoIds: List<Long>) : AllPhotoIntent
     data class ClickFavoriteIcon(val photo: Photo) : AllPhotoIntent
     data class FavoriteChanged(val photoId: Long, val isFavorite: Boolean) : AllPhotoIntent
+    data object RefreshPhotos : AllPhotoIntent
 }
 
 sealed interface AllPhotoSideEffect {
@@ -57,4 +58,5 @@ sealed interface AllPhotoSideEffect {
     data class ShowToastMessage(val message: String) : AllPhotoSideEffect
     data class DownloadImages(val imageUrls: List<String>) : AllPhotoSideEffect
     data class NotifyArchiveResult(val result: ArchiveResult) : AllPhotoSideEffect
+    data object RefreshPhotos : AllPhotoSideEffect
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoScreen.kt
@@ -39,6 +39,7 @@ import com.neki.android.core.designsystem.topbar.BackTitleTopBar
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.model.Photo
 import com.neki.android.core.model.SortOrder
+import com.neki.android.core.navigation.result.LocalResultEventBus
 import com.neki.android.core.ui.component.LoadingDialog
 import com.neki.android.feature.archive.api.ArchiveNavKey
 import com.neki.android.core.ui.compose.collectWithLifecycle
@@ -72,6 +73,7 @@ internal fun AllPhotoRoute(
     val lazyState = rememberLazyStaggeredGridState()
     val coroutineScope = rememberCoroutineScope()
     val nekiToast = remember { NekiToast(context) }
+    val resultEventBus = LocalResultEventBus.current
 
     viewModel.store.sideEffects.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
@@ -110,6 +112,10 @@ internal fun AllPhotoRoute(
                         nekiToast.showToast(text = "다운로드에 실패했어요")
                         Timber.e(e)
                     }
+            }
+
+            is AllPhotoSideEffect.NotifyArchiveResult -> {
+                resultEventBus.sendResult(result = sideEffect.result, allowDuplicate = false)
             }
         }
     }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoScreen.kt
@@ -117,6 +117,8 @@ internal fun AllPhotoRoute(
             is AllPhotoSideEffect.NotifyArchiveResult -> {
                 resultEventBus.sendResult(result = sideEffect.result, allowDuplicate = false)
             }
+
+            AllPhotoSideEffect.RefreshPhotos -> pagingItems.refresh()
         }
     }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoScreen.kt
@@ -40,6 +40,7 @@ import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.model.Photo
 import com.neki.android.core.model.SortOrder
 import com.neki.android.core.navigation.result.LocalResultEventBus
+import com.neki.android.feature.archive.api.AllPhotoResult
 import com.neki.android.core.ui.component.LoadingDialog
 import com.neki.android.feature.archive.api.ArchiveNavKey
 import com.neki.android.core.ui.compose.collectWithLifecycle
@@ -114,8 +115,8 @@ internal fun AllPhotoRoute(
                     }
             }
 
-            is AllPhotoSideEffect.NotifyArchiveResult -> {
-                resultEventBus.sendResult(result = sideEffect.result, allowDuplicate = false)
+            AllPhotoSideEffect.NotifyResult -> {
+                resultEventBus.sendResult(result = AllPhotoResult, allowDuplicate = false)
             }
 
             AllPhotoSideEffect.RefreshPhotos -> pagingItems.refresh()

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoViewModel.kt
@@ -11,6 +11,7 @@ import com.neki.android.core.model.Photo
 import com.neki.android.core.model.SortOrder
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
+import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.impl.model.SelectMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
@@ -241,6 +242,7 @@ class AllPhotoViewModel @Inject constructor(
                         )
                     }
                     postSideEffect(AllPhotoSideEffect.ShowToastMessage("사진을 삭제했어요"))
+                    postSideEffect(AllPhotoSideEffect.NotifyArchiveResult(ArchiveResult.PhotoDeleted(selectedPhotoIds)))
                 }
                 .onFailure { e ->
                     Timber.e(e)

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoViewModel.kt
@@ -121,6 +121,13 @@ class AllPhotoViewModel @Inject constructor(
                 updatedFavorites.update { it + (photo.id to newFavorite) }
                 viewModelScope.launch {
                     photoRepository.updateFavorite(photo.id, newFavorite)
+                        .onSuccess {
+                            postSideEffect(
+                                AllPhotoSideEffect.NotifyArchiveResult(
+                                    ArchiveResult.FavoriteChanged(photo.id, newFavorite),
+                                ),
+                            )
+                        }
                         .onFailure { e ->
                             Timber.e(e)
                             updatedFavorites.update { it + (photo.id to photo.isFavorite) }
@@ -132,6 +139,8 @@ class AllPhotoViewModel @Inject constructor(
             is AllPhotoIntent.FavoriteChanged -> {
                 updatedFavorites.update { it + (intent.photoId to intent.isFavorite) }
             }
+
+            AllPhotoIntent.RefreshPhotos -> postSideEffect(AllPhotoSideEffect.RefreshPhotos)
         }
     }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo/AllPhotoViewModel.kt
@@ -11,7 +11,6 @@ import com.neki.android.core.model.Photo
 import com.neki.android.core.model.SortOrder
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
-import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.archive.impl.model.SelectMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
@@ -112,9 +111,6 @@ class AllPhotoViewModel @Inject constructor(
             AllPhotoIntent.ClickDeleteDialogConfirmButton -> deleteSelectedPhotos(state, reduce, postSideEffect)
 
             // Result Intent
-            is AllPhotoIntent.PhotoDeleted -> {
-                deletedPhotoIds.update { it + intent.photoIds.toSet() }
-            }
             is AllPhotoIntent.ClickFavoriteIcon -> {
                 val photo = intent.photo
                 val newFavorite = !photo.isFavorite
@@ -122,11 +118,7 @@ class AllPhotoViewModel @Inject constructor(
                 viewModelScope.launch {
                     photoRepository.updateFavorite(photo.id, newFavorite)
                         .onSuccess {
-                            postSideEffect(
-                                AllPhotoSideEffect.NotifyArchiveResult(
-                                    ArchiveResult.FavoriteChanged(photo.id, newFavorite),
-                                ),
-                            )
+                            postSideEffect(AllPhotoSideEffect.NotifyResult)
                         }
                         .onFailure { e ->
                             Timber.e(e)
@@ -136,11 +128,11 @@ class AllPhotoViewModel @Inject constructor(
                 }
             }
 
-            is AllPhotoIntent.FavoriteChanged -> {
-                updatedFavorites.update { it + (intent.photoId to intent.isFavorite) }
+            AllPhotoIntent.RefreshPhotos -> {
+                deletedPhotoIds.value = emptySet()
+                updatedFavorites.value = emptyMap()
+                postSideEffect(AllPhotoSideEffect.RefreshPhotos)
             }
-
-            AllPhotoIntent.RefreshPhotos -> postSideEffect(AllPhotoSideEffect.RefreshPhotos)
         }
     }
 
@@ -251,7 +243,7 @@ class AllPhotoViewModel @Inject constructor(
                         )
                     }
                     postSideEffect(AllPhotoSideEffect.ShowToastMessage("사진을 삭제했어요"))
-                    postSideEffect(AllPhotoSideEffect.NotifyArchiveResult(ArchiveResult.PhotoDeleted(selectedPhotoIds)))
+                    postSideEffect(AllPhotoSideEffect.NotifyResult)
                 }
                 .onFailure { e ->
                     Timber.e(e)

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
@@ -8,7 +8,7 @@ data class PhotoDetailState(
     val currentPage: Int = 0,
     val isShowDeleteDialog: Boolean = false,
 ) {
-    val currentIndex get() = if (photos.isEmpty()) 0 else currentPage % photos.size
+    val currentIndex get() = if (photos.isEmpty()) 0 else currentPage.coerceIn(0, photos.lastIndex)
     val photo: Photo get() = photos.getOrElse(currentIndex) { Photo() }
 }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
@@ -1,7 +1,6 @@
 package com.neki.android.feature.archive.impl.photo_detail
 
 import com.neki.android.core.model.Photo
-import com.neki.android.feature.archive.api.ArchiveResult
 
 data class PhotoDetailState(
     val isLoading: Boolean = false,
@@ -37,7 +36,7 @@ sealed interface PhotoDetailIntent {
 
 sealed interface PhotoDetailSideEffect {
     data object NavigateBack : PhotoDetailSideEffect
-    data class NotifyPhotoUpdated(val result: ArchiveResult) : PhotoDetailSideEffect
+    data object NotifyPhotoUpdated : PhotoDetailSideEffect
     data class ShowToastMessage(val message: String) : PhotoDetailSideEffect
     data class DownloadImage(val imageUrl: String) : PhotoDetailSideEffect
     data class AnimateToPage(val index: Int) : PhotoDetailSideEffect

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
@@ -2,11 +2,20 @@ package com.neki.android.feature.archive.impl.photo_detail
 
 import com.neki.android.core.model.Photo
 
+enum class MemoMode {
+    Closed,
+    Preview,
+    Expanded,
+    Editing,
+}
+
 data class PhotoDetailState(
     val isLoading: Boolean = false,
     val photos: List<Photo> = emptyList(),
     val currentPage: Int = 0,
     val isShowDeleteDialog: Boolean = false,
+    val memoMode: MemoMode = MemoMode.Closed,
+    val memo: String = "",
 ) {
     val currentIndex get() = if (photos.isEmpty()) 0 else currentPage % photos.size
     val photo: Photo get() = photos.getOrElse(currentIndex) { Photo() }
@@ -26,6 +35,12 @@ sealed interface PhotoDetailIntent {
     data object ClickFavoriteIcon : PhotoDetailIntent
     data class FavoriteCommitted(val photoId: Long, val newFavorite: Boolean) : PhotoDetailIntent
     data class RevertFavorite(val photoId: Long, val originalFavorite: Boolean) : PhotoDetailIntent
+    data object ClickMemoIcon : PhotoDetailIntent
+    data object ClickMemoMore : PhotoDetailIntent
+    data object ClickMemoText : PhotoDetailIntent
+    data object ClickMemoFold : PhotoDetailIntent
+    data object ClickMemoCancel : PhotoDetailIntent
+    data class ClickMemoDone(val memo: String) : PhotoDetailIntent
     data object ClickDeleteIcon : PhotoDetailIntent
 
     // Delete Dialog Intent

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
@@ -1,6 +1,8 @@
 package com.neki.android.feature.archive.impl.photo_detail
 
 import com.neki.android.core.model.Photo
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentMapOf
 
 enum class MemoMode {
     Closed,
@@ -15,7 +17,7 @@ data class PhotoDetailState(
     val currentPage: Int = 0,
     val isShowDeleteDialog: Boolean = false,
     val memo: String = "",
-    val memoModes: Map<Long, MemoMode> = emptyMap(),
+    val memoModes: ImmutableMap<Long, MemoMode> = persistentMapOf(),
 ) {
     val currentIndex get() = if (photos.isEmpty()) 0 else currentPage % photos.size
     val photo: Photo get() = photos.getOrElse(currentIndex) { Photo() }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
@@ -14,11 +14,13 @@ data class PhotoDetailState(
     val photos: List<Photo> = emptyList(),
     val currentPage: Int = 0,
     val isShowDeleteDialog: Boolean = false,
-    val memoMode: MemoMode = MemoMode.Closed,
     val memo: String = "",
+    val memoModes: Map<Long, MemoMode> = emptyMap(),
 ) {
     val currentIndex get() = if (photos.isEmpty()) 0 else currentPage % photos.size
     val photo: Photo get() = photos.getOrElse(currentIndex) { Photo() }
+    val currentMemoMode: MemoMode get() = memoModes[photo.id] ?: MemoMode.Closed
+    fun memoModeOf(photoId: Long): MemoMode = memoModes[photoId] ?: MemoMode.Closed
 }
 
 sealed interface PhotoDetailIntent {
@@ -39,6 +41,7 @@ sealed interface PhotoDetailIntent {
     data object ClickMemoMore : PhotoDetailIntent
     data object ClickMemoText : PhotoDetailIntent
     data object ClickMemoFold : PhotoDetailIntent
+    data class MemoTextChanged(val text: String) : PhotoDetailIntent
     data object ClickMemoCancel : PhotoDetailIntent
     data class ClickMemoDone(val memo: String) : PhotoDetailIntent
     data object ClickDeleteIcon : PhotoDetailIntent

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -1,6 +1,5 @@
 package com.neki.android.feature.archive.impl.photo_detail
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -12,11 +11,16 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.neki.android.core.designsystem.DevicePreview
 import com.neki.android.core.designsystem.topbar.BackTitleTopBar
@@ -92,6 +96,8 @@ internal fun PhotoDetailScreen(
 ) {
     val isMemoActive = uiState.currentMemoMode == MemoMode.Expanded ||
         uiState.currentMemoMode == MemoMode.Editing
+    val density = LocalDensity.current
+    var actionBarHeightDp by remember { mutableStateOf(0.dp) }
 
     Column(
         modifier = Modifier
@@ -121,6 +127,7 @@ internal fun PhotoDetailScreen(
                 imageUrl = photo?.imageUrl,
                 memo = pageMemo,
                 memoMode = pageMemoMode,
+                actionBarHeight = actionBarHeightDp,
                 isScrollInProgress = pagerState.isScrollInProgress,
                 isTapEnabled = pageMemoMode != MemoMode.Expanded && pageMemoMode != MemoMode.Editing,
                 onClickLeft = { onIntent(PhotoDetailIntent.ClickLeftPhoto) },
@@ -134,8 +141,11 @@ internal fun PhotoDetailScreen(
             )
         }
 
-        AnimatedVisibility(visible = uiState.currentMemoMode != MemoMode.Editing) {
+        if (uiState.currentMemoMode != MemoMode.Editing) {
             PhotoDetailActionBar(
+                modifier = Modifier.onSizeChanged { size ->
+                    actionBarHeightDp = with(density) { size.height.toDp() }
+                },
                 isFavorite = uiState.photo.isFavorite,
                 onClickDownload = { onIntent(PhotoDetailIntent.ClickDownloadIcon) },
                 onClickFavorite = { onIntent(PhotoDetailIntent.ClickFavoriteIcon) },

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -28,6 +28,7 @@ import com.neki.android.core.designsystem.topbar.BackTitleTopBar
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.model.Photo
 import com.neki.android.core.navigation.result.LocalResultEventBus
+import com.neki.android.feature.archive.api.PhotoDetailResult
 import com.neki.android.core.ui.component.LoadingDialog
 import com.neki.android.core.ui.compose.collectWithLifecycle
 import com.neki.android.core.ui.toast.NekiToast
@@ -58,7 +59,7 @@ internal fun PhotoDetailRoute(
     viewModel.store.sideEffects.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             PhotoDetailSideEffect.NavigateBack -> navigateBack()
-            is PhotoDetailSideEffect.NotifyPhotoUpdated -> resultEventBus.sendResult(result = sideEffect.result, allowDuplicate = false)
+            PhotoDetailSideEffect.NotifyPhotoUpdated -> resultEventBus.sendResult(result = PhotoDetailResult, allowDuplicate = false)
             is PhotoDetailSideEffect.ShowToastMessage -> nekiToast.showToast(text = sideEffect.message)
             is PhotoDetailSideEffect.DownloadImage -> {
                 ImageDownloader.downloadImage(context, sideEffect.imageUrl)

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -2,7 +2,6 @@ package com.neki.android.feature.archive.impl.photo_detail
 
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -52,7 +51,9 @@ internal fun PhotoDetailRoute(
     val context = LocalContext.current
     val nekiToast = remember { NekiToast(context) }
     val resultEventBus = LocalResultEventBus.current
-    val pagerState = rememberPagerState(initialPage = uiState.currentPage) { Int.MAX_VALUE }
+    val pagerState = rememberPagerState(initialPage = uiState.currentPage) {
+        uiState.photos.size.coerceAtLeast(1)
+    }
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(pagerState) {
@@ -97,7 +98,7 @@ internal fun PhotoDetailRoute(
 internal fun PhotoDetailScreen(
     uiState: PhotoDetailState = PhotoDetailState(),
     onIntent: (PhotoDetailIntent) -> Unit = {},
-    pagerState: PagerState = rememberPagerState { Int.MAX_VALUE },
+    pagerState: PagerState = rememberPagerState { uiState.photos.size.coerceAtLeast(1) },
 ) {
     Column(
         modifier = Modifier
@@ -117,33 +118,31 @@ internal fun PhotoDetailScreen(
             state = pagerState,
             beyondViewportPageCount = 1,
         ) { page ->
-            val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
+            val index = if (uiState.photos.isEmpty()) 0 else page.coerceIn(0, uiState.photos.lastIndex)
             val zoomState = rememberZoomState()
             var contentWidth by remember { mutableIntStateOf(0) }
-            Box {
-                AsyncImage(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .onSizeChanged { contentWidth = it.width }
-                        .zoomable(
-                            zoomState = zoomState,
-                            scrollGesturePropagation = ScrollGesturePropagation.ContentEdge,
-                            onTap = { position: Offset ->
-                                if (!pagerState.isScrollInProgress && contentWidth > 0 && zoomState.scale <= 1f) {
-                                    if (position.x < contentWidth / 2) {
-                                        onIntent(PhotoDetailIntent.ClickLeftPhoto)
-                                    } else {
-                                        onIntent(PhotoDetailIntent.ClickRightPhoto)
-                                    }
+            AsyncImage(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .onSizeChanged { contentWidth = it.width }
+                    .zoomable(
+                        zoomState = zoomState,
+                        scrollGesturePropagation = ScrollGesturePropagation.ContentEdge,
+                        onTap = { position: Offset ->
+                            if (!pagerState.isScrollInProgress && contentWidth > 0 && zoomState.scale <= 1f) {
+                                if (position.x < contentWidth / 2) {
+                                    onIntent(PhotoDetailIntent.ClickLeftPhoto)
+                                } else {
+                                    onIntent(PhotoDetailIntent.ClickRightPhoto)
                                 }
-                            },
-                        ),
-                    model = uiState.photos.getOrNull(index)?.imageUrl,
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
-                    onSuccess = { state -> zoomState.setContentSize(state.painter.intrinsicSize) },
-                )
-            }
+                            }
+                        },
+                    ),
+                model = uiState.photos.getOrNull(index)?.imageUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                onSuccess = { state -> zoomState.setContentSize(state.painter.intrinsicSize) },
+            )
         }
 
         PhotoDetailActionBar(

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -18,10 +18,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import net.engawapg.lib.zoomable.ScrollGesturePropagation
+import net.engawapg.lib.zoomable.rememberZoomState
+import net.engawapg.lib.zoomable.zoomable
 import com.neki.android.core.designsystem.DevicePreview
 import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
 import com.neki.android.core.designsystem.topbar.BackTitleTopBar
@@ -107,39 +111,49 @@ internal fun PhotoDetailScreen(
         HorizontalPager(
             modifier = Modifier
                 .fillMaxWidth()
-                .weight(1f),
+                .weight(1f)
+                .clipToBounds(),
             state = pagerState,
             beyondViewportPageCount = 1,
         ) { page ->
             val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
+            val zoomState = rememberZoomState()
             Box {
                 AsyncImage(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .zoomable(
+                            zoomState = zoomState,
+                            scrollGesturePropagation = ScrollGesturePropagation.NotZoomed,
+                        ),
                     model = uiState.photos.getOrNull(index)?.imageUrl,
                     contentDescription = null,
                     contentScale = ContentScale.Fit,
+                    onSuccess = { state -> zoomState.setContentSize(state.painter.intrinsicSize) },
                 )
-                Row(modifier = Modifier.matchParentSize()) {
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
-                            .noRippleClickableSingle {
-                                if (!pagerState.isScrollInProgress) {
-                                    onIntent(PhotoDetailIntent.ClickLeftPhoto)
-                                }
-                            },
-                    )
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
-                            .noRippleClickableSingle {
-                                if (!pagerState.isScrollInProgress) {
-                                    onIntent(PhotoDetailIntent.ClickRightPhoto)
-                                }
-                            },
-                    )
+                if (zoomState.scale <= 1f) {
+                    Row(modifier = Modifier.matchParentSize()) {
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxHeight()
+                                .noRippleClickableSingle {
+                                    if (!pagerState.isScrollInProgress) {
+                                        onIntent(PhotoDetailIntent.ClickLeftPhoto)
+                                    }
+                                },
+                        )
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxHeight()
+                                .noRippleClickableSingle {
+                                    if (!pagerState.isScrollInProgress) {
+                                        onIntent(PhotoDetailIntent.ClickRightPhoto)
+                                    }
+                                },
+                        )
+                    }
                 }
             }
         }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -1,23 +1,34 @@
 package com.neki.android.feature.archive.impl.photo_detail
 
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -94,60 +105,101 @@ internal fun PhotoDetailScreen(
     onIntent: (PhotoDetailIntent) -> Unit = {},
     pagerState: PagerState = rememberPagerState { Int.MAX_VALUE },
 ) {
-    Column(
+    val density = LocalDensity.current
+    var actionBarHeightPx by remember { mutableIntStateOf(0) }
+    val actionBarHeight = with(density) { actionBarHeightPx.toDp() }
+
+    Box(
         modifier = Modifier
             .fillMaxSize()
             .background(NekiTheme.colorScheme.white),
     ) {
-        BackTitleTopBar(
-            title = uiState.photo.date,
-            onBack = { onIntent(PhotoDetailIntent.ClickBackIcon) },
-        )
+        Column(modifier = Modifier.fillMaxSize()) {
+            BackTitleTopBar(
+                title = uiState.photo.date,
+                onBack = { onIntent(PhotoDetailIntent.ClickBackIcon) },
+            )
 
-        HorizontalPager(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-            state = pagerState,
-            beyondViewportPageCount = 1,
-        ) { page ->
-            val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
-            Box {
-                AsyncImage(
-                    modifier = Modifier.fillMaxSize(),
-                    model = uiState.photos.getOrNull(index)?.imageUrl,
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
-                )
-                Row(modifier = Modifier.matchParentSize()) {
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
-                            .noRippleClickableSingle {
-                                if (!pagerState.isScrollInProgress) {
-                                    onIntent(PhotoDetailIntent.ClickLeftPhoto)
-                                }
-                            },
+            val isMemoActive = uiState.memoMode == MemoMode.Expanded ||
+                uiState.memoMode == MemoMode.Editing
+
+            HorizontalPager(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                state = pagerState,
+                beyondViewportPageCount = 1,
+                userScrollEnabled = !isMemoActive,
+            ) { page ->
+                val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
+                Box {
+                    AsyncImage(
+                        modifier = Modifier.fillMaxSize(),
+                        model = uiState.photos.getOrNull(index)?.imageUrl,
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
                     )
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
-                            .noRippleClickableSingle {
-                                if (!pagerState.isScrollInProgress) {
-                                    onIntent(PhotoDetailIntent.ClickRightPhoto)
-                                }
-                            },
-                    )
+                    if (!isMemoActive) {
+                        Row(modifier = Modifier.matchParentSize()) {
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .fillMaxHeight()
+                                    .noRippleClickableSingle {
+                                        if (!pagerState.isScrollInProgress) {
+                                            onIntent(PhotoDetailIntent.ClickLeftPhoto)
+                                        }
+                                    },
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .fillMaxHeight()
+                                    .noRippleClickableSingle {
+                                        if (!pagerState.isScrollInProgress) {
+                                            onIntent(PhotoDetailIntent.ClickRightPhoto)
+                                        }
+                                    },
+                            )
+                        }
+                    }
                 }
             }
+
+            Spacer(modifier = Modifier.height(actionBarHeight))
+        }
+
+        // Expanded/Editing 모드일 때 dim 오버레이
+        AnimatedVisibility(
+            visible = uiState.memoMode == MemoMode.Expanded || uiState.memoMode == MemoMode.Editing,
+            enter = fadeIn(),
+            exit = fadeOut(),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0x80202227))
+                    .noRippleClickableSingle { onIntent(PhotoDetailIntent.ClickMemoFold) },
+            )
         }
 
         PhotoDetailActionBar(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .onSizeChanged {
+                    if (uiState.memoMode == MemoMode.Closed) actionBarHeightPx = it.height
+                },
             isFavorite = uiState.photo.isFavorite,
+            memo = uiState.memo,
+            memoMode = uiState.memoMode,
             onClickDownload = { onIntent(PhotoDetailIntent.ClickDownloadIcon) },
             onClickFavorite = { onIntent(PhotoDetailIntent.ClickFavoriteIcon) },
+            onClickMemo = { onIntent(PhotoDetailIntent.ClickMemoIcon) },
+            onClickMemoMore = { onIntent(PhotoDetailIntent.ClickMemoMore) },
+            onClickMemoText = { onIntent(PhotoDetailIntent.ClickMemoText) },
+            onClickMemoFold = { onIntent(PhotoDetailIntent.ClickMemoFold) },
+            onClickMemoCancel = { onIntent(PhotoDetailIntent.ClickMemoCancel) },
+            onClickMemoDone = { onIntent(PhotoDetailIntent.ClickMemoDone(it)) },
             onClickDelete = { onIntent(PhotoDetailIntent.ClickDeleteIcon) },
         )
     }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -120,7 +120,7 @@ internal fun PhotoDetailScreen(
             val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
             val zoomState = rememberZoomState()
             var contentWidth by remember { mutableIntStateOf(0) }
-            Box(modifier = Modifier.clipToBounds()) {
+            Box {
                 AsyncImage(
                     modifier = Modifier
                         .fillMaxSize()

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -1,50 +1,35 @@
 package com.neki.android.feature.archive.impl.photo_detail
 
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil3.compose.AsyncImage
 import com.neki.android.core.designsystem.DevicePreview
-import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
 import com.neki.android.core.designsystem.topbar.BackTitleTopBar
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.model.Photo
 import com.neki.android.core.navigation.result.LocalResultEventBus
-import com.neki.android.feature.archive.api.PhotoDetailResult
 import com.neki.android.core.ui.component.LoadingDialog
 import com.neki.android.core.ui.compose.collectWithLifecycle
 import com.neki.android.core.ui.toast.NekiToast
+import com.neki.android.feature.archive.api.PhotoDetailResult
 import com.neki.android.feature.archive.impl.component.DeletePhotoDialog
 import com.neki.android.feature.archive.impl.photo_detail.component.PhotoDetailActionBar
+import com.neki.android.feature.archive.impl.photo_detail.component.PhotoDetailImageItem
 import com.neki.android.feature.archive.impl.util.ImageDownloader
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -105,103 +90,59 @@ internal fun PhotoDetailScreen(
     onIntent: (PhotoDetailIntent) -> Unit = {},
     pagerState: PagerState = rememberPagerState { Int.MAX_VALUE },
 ) {
-    val density = LocalDensity.current
-    var actionBarHeightPx by remember { mutableIntStateOf(0) }
-    val actionBarHeight = with(density) { actionBarHeightPx.toDp() }
+    val isMemoActive = uiState.currentMemoMode == MemoMode.Expanded ||
+        uiState.currentMemoMode == MemoMode.Editing
 
-    Box(
+    Column(
         modifier = Modifier
             .fillMaxSize()
             .background(NekiTheme.colorScheme.white),
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            BackTitleTopBar(
-                title = uiState.photo.date,
-                onBack = { onIntent(PhotoDetailIntent.ClickBackIcon) },
-            )
-
-            val isMemoActive = uiState.memoMode == MemoMode.Expanded ||
-                uiState.memoMode == MemoMode.Editing
-
-            HorizontalPager(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-                state = pagerState,
-                beyondViewportPageCount = 1,
-                userScrollEnabled = !isMemoActive,
-            ) { page ->
-                val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
-                Box {
-                    AsyncImage(
-                        modifier = Modifier.fillMaxSize(),
-                        model = uiState.photos.getOrNull(index)?.imageUrl,
-                        contentDescription = null,
-                        contentScale = ContentScale.Fit,
-                    )
-                    if (!isMemoActive) {
-                        Row(modifier = Modifier.matchParentSize()) {
-                            Box(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .fillMaxHeight()
-                                    .noRippleClickableSingle {
-                                        if (!pagerState.isScrollInProgress) {
-                                            onIntent(PhotoDetailIntent.ClickLeftPhoto)
-                                        }
-                                    },
-                            )
-                            Box(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .fillMaxHeight()
-                                    .noRippleClickableSingle {
-                                        if (!pagerState.isScrollInProgress) {
-                                            onIntent(PhotoDetailIntent.ClickRightPhoto)
-                                        }
-                                    },
-                            )
-                        }
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(actionBarHeight))
-        }
-
-        // Expanded/Editing 모드일 때 dim 오버레이
-        AnimatedVisibility(
-            visible = uiState.memoMode == MemoMode.Expanded || uiState.memoMode == MemoMode.Editing,
-            enter = fadeIn(),
-            exit = fadeOut(),
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color(0x80202227))
-                    .noRippleClickableSingle { onIntent(PhotoDetailIntent.ClickMemoFold) },
-            )
-        }
-
-        PhotoDetailActionBar(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .onSizeChanged {
-                    if (uiState.memoMode == MemoMode.Closed) actionBarHeightPx = it.height
-                },
-            isFavorite = uiState.photo.isFavorite,
-            memo = uiState.memo,
-            memoMode = uiState.memoMode,
-            onClickDownload = { onIntent(PhotoDetailIntent.ClickDownloadIcon) },
-            onClickFavorite = { onIntent(PhotoDetailIntent.ClickFavoriteIcon) },
-            onClickMemo = { onIntent(PhotoDetailIntent.ClickMemoIcon) },
-            onClickMemoMore = { onIntent(PhotoDetailIntent.ClickMemoMore) },
-            onClickMemoText = { onIntent(PhotoDetailIntent.ClickMemoText) },
-            onClickMemoFold = { onIntent(PhotoDetailIntent.ClickMemoFold) },
-            onClickMemoCancel = { onIntent(PhotoDetailIntent.ClickMemoCancel) },
-            onClickMemoDone = { onIntent(PhotoDetailIntent.ClickMemoDone(it)) },
-            onClickDelete = { onIntent(PhotoDetailIntent.ClickDeleteIcon) },
+        BackTitleTopBar(
+            title = uiState.photo.date,
+            onBack = { onIntent(PhotoDetailIntent.ClickBackIcon) },
         )
+
+        HorizontalPager(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            state = pagerState,
+            beyondViewportPageCount = 1,
+            userScrollEnabled = !isMemoActive,
+        ) { page ->
+            val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
+            val photo = uiState.photos.getOrNull(index)
+            val pageMemoMode = uiState.memoModeOf(photo?.id ?: 0L)
+            val pageMemo = if (index == uiState.currentIndex) uiState.memo
+            else photo?.memo.orEmpty()
+
+            PhotoDetailImageItem(
+                imageUrl = photo?.imageUrl,
+                memo = pageMemo,
+                memoMode = pageMemoMode,
+                isScrollInProgress = pagerState.isScrollInProgress,
+                isTapEnabled = pageMemoMode != MemoMode.Expanded && pageMemoMode != MemoMode.Editing,
+                onClickLeft = { onIntent(PhotoDetailIntent.ClickLeftPhoto) },
+                onClickRight = { onIntent(PhotoDetailIntent.ClickRightPhoto) },
+                onClickMemoMore = { onIntent(PhotoDetailIntent.ClickMemoMore) },
+                onClickMemoText = { onIntent(PhotoDetailIntent.ClickMemoText) },
+                onClickMemoFold = { onIntent(PhotoDetailIntent.ClickMemoFold) },
+                onClickMemoCancel = { onIntent(PhotoDetailIntent.ClickMemoCancel) },
+                onClickMemoDone = { onIntent(PhotoDetailIntent.ClickMemoDone(it)) },
+                onMemoTextChanged = { onIntent(PhotoDetailIntent.MemoTextChanged(it)) },
+            )
+        }
+
+        AnimatedVisibility(visible = uiState.currentMemoMode != MemoMode.Editing) {
+            PhotoDetailActionBar(
+                isFavorite = uiState.photo.isFavorite,
+                onClickDownload = { onIntent(PhotoDetailIntent.ClickDownloadIcon) },
+                onClickFavorite = { onIntent(PhotoDetailIntent.ClickFavoriteIcon) },
+                onClickMemo = { onIntent(PhotoDetailIntent.ClickMemoIcon) },
+                onClickDelete = { onIntent(PhotoDetailIntent.ClickDeleteIcon) },
+            )
+        }
     }
 
     if (uiState.isShowDeleteDialog) {

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -4,8 +4,6 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.pager.HorizontalPager
@@ -14,32 +12,35 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
-import net.engawapg.lib.zoomable.ScrollGesturePropagation
-import net.engawapg.lib.zoomable.rememberZoomState
-import net.engawapg.lib.zoomable.zoomable
 import com.neki.android.core.designsystem.DevicePreview
-import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
 import com.neki.android.core.designsystem.topbar.BackTitleTopBar
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.model.Photo
 import com.neki.android.core.navigation.result.LocalResultEventBus
-import com.neki.android.feature.archive.api.PhotoDetailResult
 import com.neki.android.core.ui.component.LoadingDialog
 import com.neki.android.core.ui.compose.collectWithLifecycle
 import com.neki.android.core.ui.toast.NekiToast
+import com.neki.android.feature.archive.api.PhotoDetailResult
 import com.neki.android.feature.archive.impl.component.DeletePhotoDialog
 import com.neki.android.feature.archive.impl.photo_detail.component.PhotoDetailActionBar
 import com.neki.android.feature.archive.impl.util.ImageDownloader
 import kotlinx.coroutines.launch
+import net.engawapg.lib.zoomable.ScrollGesturePropagation
+import net.engawapg.lib.zoomable.rememberZoomState
+import net.engawapg.lib.zoomable.zoomable
 import timber.log.Timber
 
 @Composable
@@ -118,43 +119,30 @@ internal fun PhotoDetailScreen(
         ) { page ->
             val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
             val zoomState = rememberZoomState()
-            Box {
+            var contentWidth by remember { mutableIntStateOf(0) }
+            Box(modifier = Modifier.clipToBounds()) {
                 AsyncImage(
                     modifier = Modifier
                         .fillMaxSize()
+                        .onSizeChanged { contentWidth = it.width }
                         .zoomable(
                             zoomState = zoomState,
-                            scrollGesturePropagation = ScrollGesturePropagation.NotZoomed,
+                            scrollGesturePropagation = ScrollGesturePropagation.ContentEdge,
+                            onTap = { position: Offset ->
+                                if (!pagerState.isScrollInProgress && contentWidth > 0 && zoomState.scale <= 1f) {
+                                    if (position.x < contentWidth / 2) {
+                                        onIntent(PhotoDetailIntent.ClickLeftPhoto)
+                                    } else {
+                                        onIntent(PhotoDetailIntent.ClickRightPhoto)
+                                    }
+                                }
+                            },
                         ),
                     model = uiState.photos.getOrNull(index)?.imageUrl,
                     contentDescription = null,
                     contentScale = ContentScale.Fit,
                     onSuccess = { state -> zoomState.setContentSize(state.painter.intrinsicSize) },
                 )
-                if (zoomState.scale <= 1f) {
-                    Row(modifier = Modifier.matchParentSize()) {
-                        Box(
-                            modifier = Modifier
-                                .weight(1f)
-                                .fillMaxHeight()
-                                .noRippleClickableSingle {
-                                    if (!pagerState.isScrollInProgress) {
-                                        onIntent(PhotoDetailIntent.ClickLeftPhoto)
-                                    }
-                                },
-                        )
-                        Box(
-                            modifier = Modifier
-                                .weight(1f)
-                                .fillMaxHeight()
-                                .noRippleClickableSingle {
-                                    if (!pagerState.isScrollInProgress) {
-                                        onIntent(PhotoDetailIntent.ClickRightPhoto)
-                                    }
-                                },
-                        )
-                    }
-                }
             }
         }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
@@ -75,7 +75,12 @@ class PhotoDetailViewModel @AssistedInject constructor(
     ) {
         when (intent) {
             // TopBar Intent
-            PhotoDetailIntent.ClickBackIcon -> postSideEffect(PhotoDetailSideEffect.NavigateBack)
+            PhotoDetailIntent.ClickBackIcon -> {
+                if (state.memo != state.photo.memo) {
+                    saveMemo(state, reduce, postSideEffect)
+                }
+                postSideEffect(PhotoDetailSideEffect.NavigateBack)
+            }
 
             // Pager Intent
             PhotoDetailIntent.ClickLeftPhoto -> {
@@ -92,7 +97,6 @@ class PhotoDetailViewModel @AssistedInject constructor(
                     copy(
                         currentPage = intent.page,
                         memo = photos.getOrNull(newIndex)?.memo.orEmpty(),
-                        memoMode = if (memoMode == MemoMode.Preview) MemoMode.Preview else MemoMode.Closed,
                     )
                 }
                 preloadIfNeeded(reduce)
@@ -117,16 +121,40 @@ class PhotoDetailViewModel @AssistedInject constructor(
             }
 
             // Memo Intent
+            is PhotoDetailIntent.MemoTextChanged -> reduce { copy(memo = intent.text) }
             PhotoDetailIntent.ClickMemoIcon -> reduce {
-                copy(memoMode = if (memoMode == MemoMode.Closed) MemoMode.Preview else MemoMode.Closed)
+                val photoId = photo.id
+                val current = memoModeOf(photoId)
+                val newMode = if (current == MemoMode.Closed) MemoMode.Preview else MemoMode.Closed
+                copy(memoModes = memoModes + (photoId to newMode))
             }
-            PhotoDetailIntent.ClickMemoMore -> reduce { copy(memoMode = MemoMode.Expanded) }
-            PhotoDetailIntent.ClickMemoFold -> reduce { copy(memoMode = MemoMode.Preview) }
-            PhotoDetailIntent.ClickMemoText -> reduce { copy(memoMode = MemoMode.Editing) }
-            PhotoDetailIntent.ClickMemoCancel -> reduce { copy(memoMode = MemoMode.Preview) }
+            PhotoDetailIntent.ClickMemoMore -> reduce {
+                copy(memoModes = memoModes + (photo.id to MemoMode.Expanded))
+            }
+            PhotoDetailIntent.ClickMemoText -> reduce {
+                copy(memoModes = memoModes + (photo.id to MemoMode.Editing))
+            }
+            PhotoDetailIntent.ClickMemoFold -> reduce {
+                copy(
+                    memo = photo.memo,
+                    memoModes = memoModes + (photo.id to MemoMode.Preview),
+                )
+            }
+            PhotoDetailIntent.ClickMemoCancel -> reduce {
+                copy(
+                    memo = photo.memo,
+                    memoModes = memoModes + (photo.id to MemoMode.Preview),
+                )
+            }
             is PhotoDetailIntent.ClickMemoDone -> {
-                reduce { copy(memo = intent.memo, memoMode = MemoMode.Preview) }
-                // TODO: 메모 저장 API 호출
+                val photoId = state.photo.id
+                reduce {
+                    copy(
+                        memo = intent.memo,
+                        memoModes = memoModes + (photoId to MemoMode.Preview),
+                    )
+                }
+                saveMemo(state.copy(memo = intent.memo), reduce, postSideEffect)
             }
 
             PhotoDetailIntent.ClickDeleteIcon -> reduce { copy(isShowDeleteDialog = true) }
@@ -135,6 +163,39 @@ class PhotoDetailViewModel @AssistedInject constructor(
             PhotoDetailIntent.DismissDeleteDialog -> reduce { copy(isShowDeleteDialog = false) }
             PhotoDetailIntent.ClickDeleteDialogCancelButton -> reduce { copy(isShowDeleteDialog = false) }
             PhotoDetailIntent.ClickDeleteDialogConfirmButton -> handleDelete(state, reduce, postSideEffect)
+        }
+    }
+
+    private fun saveMemo(
+        state: PhotoDetailState,
+        reduce: (PhotoDetailState.() -> PhotoDetailState) -> Unit,
+        postSideEffect: (PhotoDetailSideEffect) -> Unit,
+    ) {
+        val photoId = state.photo.id
+        val newMemo = state.memo
+        val oldMemo = state.photo.memo
+        if (newMemo == oldMemo) return
+        reduce {
+            copy(
+                photos = photos.map { p ->
+                    if (p.id == photoId) p.copy(memo = newMemo) else p
+                },
+            )
+        }
+        viewModelScope.launch {
+            photoRepository.updateMemo(photoId, newMemo)
+                .onFailure { e ->
+                    Timber.e(e, "updateMemo failed")
+                    reduce {
+                        copy(
+                            memo = oldMemo,
+                            photos = photos.map { p ->
+                                if (p.id == photoId) p.copy(memo = oldMemo) else p
+                            },
+                        )
+                    }
+                    postSideEffect(PhotoDetailSideEffect.ShowToastMessage("메모 저장에 실패했어요"))
+                }
         }
     }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
@@ -83,7 +83,11 @@ class PhotoDetailViewModel @AssistedInject constructor(
                 }
             }
 
-            PhotoDetailIntent.ClickRightPhoto -> postSideEffect(PhotoDetailSideEffect.AnimateToPage(state.currentPage + 1))
+            PhotoDetailIntent.ClickRightPhoto -> {
+                if (state.currentPage < state.photos.lastIndex) {
+                    postSideEffect(PhotoDetailSideEffect.AnimateToPage(state.currentPage + 1))
+                }
+            }
 
             is PhotoDetailIntent.PageChanged -> {
                 reduce { copy(currentPage = intent.page) }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
@@ -7,7 +7,6 @@ import com.neki.android.core.dataapi.repository.PhotoRepository
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
 import com.neki.android.feature.archive.api.ArchiveNavKey
-import com.neki.android.feature.archive.api.ArchiveResult
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -96,7 +95,7 @@ class PhotoDetailViewModel @AssistedInject constructor(
             PhotoDetailIntent.ClickFavoriteIcon -> handleFavoriteToggle(state, reduce)
             is PhotoDetailIntent.FavoriteCommitted -> {
                 committedFavorites[intent.photoId] = intent.newFavorite
-                postSideEffect(PhotoDetailSideEffect.NotifyPhotoUpdated(ArchiveResult.FavoriteChanged(intent.photoId, intent.newFavorite)))
+                postSideEffect(PhotoDetailSideEffect.NotifyPhotoUpdated)
             }
 
             is PhotoDetailIntent.RevertFavorite -> {
@@ -145,7 +144,7 @@ class PhotoDetailViewModel @AssistedInject constructor(
             photoRepository.deletePhoto(state.photo.id)
                 .onSuccess {
                     reduce { copy(isLoading = false) }
-                    postSideEffect(PhotoDetailSideEffect.NotifyPhotoUpdated(ArchiveResult.PhotoDeleted(state.photo.id)))
+                    postSideEffect(PhotoDetailSideEffect.NotifyPhotoUpdated)
                     postSideEffect(PhotoDetailSideEffect.ShowToastMessage("사진을 삭제했어요"))
                     postSideEffect(PhotoDetailSideEffect.NavigateBack)
                 }
@@ -195,7 +194,6 @@ class PhotoDetailViewModel @AssistedInject constructor(
 
     override fun onCleared() {
         super.onCleared()
-
         val state = store.uiState.value
         val currentPhoto = state.photo
         val committedFavorite = committedFavorites[currentPhoto.id] ?: return

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
@@ -36,6 +36,7 @@ class PhotoDetailViewModel @AssistedInject constructor(
             initialState = PhotoDetailState(
                 photos = key.photos,
                 currentPage = key.initialIndex,
+                memo = key.photos.getOrNull(key.initialIndex)?.memo.orEmpty(),
             ),
             onIntent = ::onIntent,
         )
@@ -86,7 +87,14 @@ class PhotoDetailViewModel @AssistedInject constructor(
             PhotoDetailIntent.ClickRightPhoto -> postSideEffect(PhotoDetailSideEffect.AnimateToPage(state.currentPage + 1))
 
             is PhotoDetailIntent.PageChanged -> {
-                reduce { copy(currentPage = intent.page) }
+                reduce {
+                    val newIndex = if (photos.isEmpty()) 0 else intent.page % photos.size
+                    copy(
+                        currentPage = intent.page,
+                        memo = photos.getOrNull(newIndex)?.memo.orEmpty(),
+                        memoMode = if (memoMode == MemoMode.Preview) MemoMode.Preview else MemoMode.Closed,
+                    )
+                }
                 preloadIfNeeded(reduce)
             }
 
@@ -106,6 +114,19 @@ class PhotoDetailViewModel @AssistedInject constructor(
                         },
                     )
                 }
+            }
+
+            // Memo Intent
+            PhotoDetailIntent.ClickMemoIcon -> reduce {
+                copy(memoMode = if (memoMode == MemoMode.Closed) MemoMode.Preview else MemoMode.Closed)
+            }
+            PhotoDetailIntent.ClickMemoMore -> reduce { copy(memoMode = MemoMode.Expanded) }
+            PhotoDetailIntent.ClickMemoFold -> reduce { copy(memoMode = MemoMode.Preview) }
+            PhotoDetailIntent.ClickMemoText -> reduce { copy(memoMode = MemoMode.Editing) }
+            PhotoDetailIntent.ClickMemoCancel -> reduce { copy(memoMode = MemoMode.Preview) }
+            is PhotoDetailIntent.ClickMemoDone -> {
+                reduce { copy(memo = intent.memo, memoMode = MemoMode.Preview) }
+                // TODO: 메모 저장 API 호출
             }
 
             PhotoDetailIntent.ClickDeleteIcon -> reduce { copy(isShowDeleteDialog = true) }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
@@ -11,6 +11,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -76,9 +77,6 @@ class PhotoDetailViewModel @AssistedInject constructor(
         when (intent) {
             // TopBar Intent
             PhotoDetailIntent.ClickBackIcon -> {
-                if (state.memo != state.photo.memo) {
-                    saveMemo(state, reduce, postSideEffect)
-                }
                 postSideEffect(PhotoDetailSideEffect.NavigateBack)
             }
 
@@ -126,24 +124,24 @@ class PhotoDetailViewModel @AssistedInject constructor(
                 val photoId = photo.id
                 val current = memoModeOf(photoId)
                 val newMode = if (current == MemoMode.Closed) MemoMode.Preview else MemoMode.Closed
-                copy(memoModes = memoModes + (photoId to newMode))
+                copy(memoModes = (memoModes + (photoId to newMode)).toImmutableMap())
             }
             PhotoDetailIntent.ClickMemoMore -> reduce {
-                copy(memoModes = memoModes + (photo.id to MemoMode.Expanded))
+                copy(memoModes = (memoModes + (photo.id to MemoMode.Expanded)).toImmutableMap())
             }
             PhotoDetailIntent.ClickMemoText -> reduce {
-                copy(memoModes = memoModes + (photo.id to MemoMode.Editing))
+                copy(memoModes = (memoModes + (photo.id to MemoMode.Editing)).toImmutableMap())
             }
             PhotoDetailIntent.ClickMemoFold -> reduce {
                 copy(
                     memo = photo.memo,
-                    memoModes = memoModes + (photo.id to MemoMode.Preview),
+                    memoModes = (memoModes + (photo.id to MemoMode.Preview)).toImmutableMap(),
                 )
             }
             PhotoDetailIntent.ClickMemoCancel -> reduce {
                 copy(
                     memo = photo.memo,
-                    memoModes = memoModes + (photo.id to MemoMode.Preview),
+                    memoModes = (memoModes + (photo.id to MemoMode.Preview)).toImmutableMap(),
                 )
             }
             is PhotoDetailIntent.ClickMemoDone -> {
@@ -151,7 +149,7 @@ class PhotoDetailViewModel @AssistedInject constructor(
                 reduce {
                     copy(
                         memo = intent.memo,
-                        memoModes = memoModes + (photoId to MemoMode.Preview),
+                        memoModes = (memoModes + (photoId to MemoMode.Preview)).toImmutableMap(),
                     )
                 }
                 saveMemo(state.copy(memo = intent.memo), reduce, postSideEffect)
@@ -184,6 +182,9 @@ class PhotoDetailViewModel @AssistedInject constructor(
         }
         viewModelScope.launch {
             photoRepository.updateMemo(photoId, newMemo)
+                .onSuccess {
+                    postSideEffect(PhotoDetailSideEffect.NotifyPhotoUpdated)
+                }
                 .onFailure { e ->
                     Timber.e(e, "updateMemo failed")
                     reduce {

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
@@ -107,7 +107,7 @@ internal fun MemoTextField(
                     start = 16.dp,
                     end = 16.dp,
                     top = 20.dp,
-                    bottom = if (memoMode == MemoMode.Editing) 0.dp else 20.dp,
+                    bottom = if (memoMode == MemoMode.Editing) 8.dp else 20.dp,
                 ),
         ) {
             when (memoMode) {
@@ -212,9 +212,9 @@ private fun MemoEditingContent(
         modifier = Modifier
             .fillMaxWidth()
             .focusRequester(focusRequester),
-        textStyle = NekiTheme.typography.body16Medium,
+        textStyle = NekiTheme.typography.body16Medium.copy(color = NekiTheme.colorScheme.gray700),
         inputTransformation = InputTransformation.maxLength(100),
-        cursorBrush = SolidColor(NekiTheme.colorScheme.gray900),
+        cursorBrush = SolidColor(NekiTheme.colorScheme.gray800),
         decorator = { innerTextField -> innerTextField() },
     )
     Spacer(modifier = Modifier.height(8.dp))

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
@@ -223,20 +223,25 @@ private fun MemoEditingContent(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             Text(
                 text = "$charCount/100",
                 style = NekiTheme.typography.caption12Regular,
                 color = NekiTheme.colorScheme.gray300,
             )
-            Text(
-                text = "전체 지우기",
-                modifier = Modifier.noRippleClickableSingle {
-                    memoState.edit { replace(0, length, "") }
-                },
-                style = NekiTheme.typography.caption12Medium,
-                color = NekiTheme.colorScheme.gray200,
-            )
+            NekiTextButton(
+                onClick = { memoState.edit { replace(0, length, "") } },
+                contentPadding = PaddingValues(10.dp),
+            ) {
+                Text(
+                    text = "전체 지우기",
+                    style = NekiTheme.typography.caption12Medium,
+                    color = NekiTheme.colorScheme.gray200,
+                )
+            }
         }
         Row(
             horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
@@ -72,9 +72,11 @@ internal fun MemoTextField(
         previousMemoMode = memoMode
     }
 
-    LaunchedEffect(memoState) {
-        snapshotFlow { memoState.text.toString() }
-            .collect { text -> onMemoTextChanged(text) }
+    LaunchedEffect(memoState, memoMode) {
+        if (memoMode == MemoMode.Editing) {
+            snapshotFlow { memoState.text.toString() }
+                .collect { text -> onMemoTextChanged(text) }
+        }
     }
 
     Column(

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
@@ -1,0 +1,360 @@
+package com.neki.android.feature.archive.impl.photo_detail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.maxLength
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.neki.android.core.designsystem.ComponentPreview
+import com.neki.android.core.designsystem.button.NekiTextButton
+import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
+import com.neki.android.core.designsystem.ui.theme.NekiTheme
+import com.neki.android.feature.archive.impl.photo_detail.MemoMode
+
+@Composable
+internal fun MemoTextField(
+    memo: String,
+    memoMode: MemoMode,
+    onClickMemoMore: () -> Unit,
+    onClickMemoFold: () -> Unit,
+    onClickMemoText: () -> Unit,
+    onClickMemoCancel: () -> Unit,
+    onClickMemoDone: (String) -> Unit,
+    onMemoTextChanged: (String) -> Unit,
+) {
+    val memoState = remember { TextFieldState(initialText = memo) }
+    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    var previousMemoMode by remember { mutableStateOf(memoMode) }
+
+    LaunchedEffect(memo, memoMode) {
+        if (memoMode != MemoMode.Editing) {
+            memoState.edit { replace(0, length, memo) }
+        }
+    }
+
+    LaunchedEffect(memoMode) {
+        if (memoMode == MemoMode.Editing) {
+            memoState.edit { replace(0, length, memo) }
+            focusRequester.requestFocus()
+        } else if (previousMemoMode == MemoMode.Editing) {
+            keyboardController?.hide()
+        }
+        previousMemoMode = memoMode
+    }
+
+    LaunchedEffect(memoState) {
+        snapshotFlow { memoState.text.toString() }
+            .collect { text -> onMemoTextChanged(text) }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                when (memoMode) {
+                    MemoMode.Editing -> NekiTheme.colorScheme.gray25
+                    else -> NekiTheme.colorScheme.white
+                },
+            ),
+    ) {
+        HorizontalDivider(
+            modifier = Modifier.fillMaxWidth(),
+            thickness = 1.dp,
+            color = NekiTheme.colorScheme.gray75,
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(
+                    when (memoMode) {
+                        MemoMode.Preview, MemoMode.Expanded -> Modifier.noRippleClickableSingle { onClickMemoText() }
+                        else -> Modifier
+                    },
+                )
+                .padding(
+                    start = 16.dp,
+                    end = 16.dp,
+                    top = 20.dp,
+                    bottom = if (memoMode == MemoMode.Editing) 0.dp else 20.dp,
+                ),
+        ) {
+            when (memoMode) {
+                MemoMode.Closed -> Unit
+                MemoMode.Preview -> MemoPreviewContent(
+                    memo = memo,
+                    onClickMemoMore = onClickMemoMore,
+                )
+
+                MemoMode.Expanded -> MemoExpandedContent(
+                    memoState = memoState,
+                    focusRequester = focusRequester,
+                    onClickMemoText = onClickMemoText,
+                    onClickMemoFold = onClickMemoFold,
+                )
+
+                MemoMode.Editing -> MemoEditingContent(
+                    memoState = memoState,
+                    focusRequester = focusRequester,
+                    onClickMemoCancel = onClickMemoCancel,
+                    onClickMemoDone = onClickMemoDone,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MemoPreviewContent(
+    memo: String,
+    onClickMemoMore: () -> Unit,
+) {
+    var hasOverflow by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = memo.ifEmpty { "자유롭게 메모를 입력해주세요. (최대 100자)" },
+            modifier = Modifier.weight(1f),
+            style = NekiTheme.typography.body16Regular,
+            color = if (memo.isEmpty()) NekiTheme.colorScheme.gray300
+            else NekiTheme.colorScheme.gray700,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            onTextLayout = { result -> hasOverflow = result.hasVisualOverflow },
+        )
+        if (hasOverflow) {
+            Text(
+                text = "더보기",
+                modifier = Modifier.noRippleClickableSingle { onClickMemoMore() },
+                style = NekiTheme.typography.body16Medium,
+                color = NekiTheme.colorScheme.gray300,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.MemoExpandedContent(
+    memoState: TextFieldState,
+    focusRequester: FocusRequester,
+    onClickMemoText: () -> Unit,
+    onClickMemoFold: () -> Unit,
+) {
+    BasicTextField(
+        state = memoState,
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusRequester(focusRequester)
+            .onFocusChanged {
+                if (it.isFocused) onClickMemoText()
+            },
+        textStyle = NekiTheme.typography.body16Medium,
+        readOnly = true,
+        inputTransformation = InputTransformation.maxLength(100),
+        cursorBrush = SolidColor(Color.Transparent),
+        decorator = { innerTextField -> innerTextField() },
+    )
+    Text(
+        text = "메모 접기",
+        modifier = Modifier
+            .align(Alignment.End)
+            .noRippleClickableSingle { onClickMemoFold() },
+        style = NekiTheme.typography.body16Medium,
+        color = NekiTheme.colorScheme.gray200,
+    )
+}
+
+@Composable
+private fun MemoEditingContent(
+    memoState: TextFieldState,
+    focusRequester: FocusRequester,
+    onClickMemoCancel: () -> Unit,
+    onClickMemoDone: (String) -> Unit,
+) {
+    val charCount = memoState.text.length
+
+    BasicTextField(
+        state = memoState,
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusRequester(focusRequester),
+        textStyle = NekiTheme.typography.body16Medium,
+        inputTransformation = InputTransformation.maxLength(100),
+        cursorBrush = SolidColor(NekiTheme.colorScheme.gray900),
+        decorator = { innerTextField -> innerTextField() },
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "$charCount/100",
+                style = NekiTheme.typography.caption12Regular,
+                color = NekiTheme.colorScheme.gray300,
+            )
+            Text(
+                text = "전체 지우기",
+                modifier = Modifier.noRippleClickableSingle {
+                    memoState.edit { replace(0, length, "") }
+                },
+                style = NekiTheme.typography.caption12Medium,
+                color = NekiTheme.colorScheme.gray200,
+            )
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            NekiTextButton(
+                onClick = onClickMemoCancel,
+                contentPadding = PaddingValues(10.dp),
+            ) {
+                Text(
+                    text = "취소",
+                    style = NekiTheme.typography.body16SemiBold,
+                    color = NekiTheme.colorScheme.gray800,
+                )
+            }
+            NekiTextButton(
+                onClick = { onClickMemoDone(memoState.text.toString()) },
+                contentPadding = PaddingValues(10.dp),
+            ) {
+                Text(
+                    text = "완료",
+                    style = NekiTheme.typography.body16SemiBold,
+                    color = NekiTheme.colorScheme.primary500,
+                )
+            }
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun MemoTextFieldPreviewPreview() {
+    NekiTheme {
+        Box {
+            MemoTextField(
+                memo = "짧은 메모",
+                memoMode = MemoMode.Preview,
+                onClickMemoMore = {},
+                onClickMemoFold = {},
+                onClickMemoText = {},
+                onClickMemoCancel = {},
+                onClickMemoDone = {},
+                onMemoTextChanged = {},
+            )
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun MemoTextFieldPreviewOverflowPreview() {
+    NekiTheme {
+        Box {
+            MemoTextField(
+                memo = "재밌었던 날인데 메모가 길어서 한 줄에 다 안 들어갈 수도 있어요 이렇게 길면 더보기가 나와야 해요",
+                memoMode = MemoMode.Preview,
+                onClickMemoMore = {},
+                onClickMemoFold = {},
+                onClickMemoText = {},
+                onClickMemoCancel = {},
+                onClickMemoDone = {},
+                onMemoTextChanged = {},
+            )
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun MemoTextFieldExpandedPreview() {
+    NekiTheme {
+        Box {
+            MemoTextField(
+                memo = "재밌었던 날인데 메모가 길어서 한 줄에 다 안 들어갈 수도 있어요",
+                memoMode = MemoMode.Expanded,
+                onClickMemoMore = {},
+                onClickMemoFold = {},
+                onClickMemoText = {},
+                onClickMemoCancel = {},
+                onClickMemoDone = {},
+                onMemoTextChanged = {},
+            )
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun MemoTextFieldEditingPreview() {
+    NekiTheme {
+        Box {
+            MemoTextField(
+                memo = "재밌었던 날",
+                memoMode = MemoMode.Editing,
+                onClickMemoMore = {},
+                onClickMemoFold = {},
+                onClickMemoText = {},
+                onClickMemoCancel = {},
+                onClickMemoDone = {},
+                onMemoTextChanged = {},
+            )
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun MemoTextFieldEmptyPreview() {
+    NekiTheme {
+        Box {
+            MemoTextField(
+                memo = "",
+                memoMode = MemoMode.Preview,
+                onClickMemoMore = {},
+                onClickMemoFold = {},
+                onClickMemoText = {},
+                onClickMemoCancel = {},
+                onClickMemoDone = {},
+                onMemoTextChanged = {},
+            )
+        }
+    }
+}

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailActionBar.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailActionBar.kt
@@ -1,93 +1,411 @@
 package com.neki.android.feature.archive.impl.photo_detail.component
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.maxLength
+import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.neki.android.core.designsystem.ComponentPreview
 import com.neki.android.core.designsystem.R
 import com.neki.android.core.designsystem.actionbar.NekiBothSidesActionBar
 import com.neki.android.core.designsystem.button.NekiIconButton
+import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
+import com.neki.android.feature.archive.impl.photo_detail.MemoMode
 
 @Composable
 internal fun PhotoDetailActionBar(
     isFavorite: Boolean,
+    memo: String,
+    memoMode: MemoMode,
     modifier: Modifier = Modifier,
     onClickDownload: () -> Unit = {},
     onClickFavorite: () -> Unit = {},
+    onClickMemo: () -> Unit = {},
+    onClickMemoMore: () -> Unit = {},
+    onClickMemoText: () -> Unit = {},
+    onClickMemoFold: () -> Unit = {},
+    onClickMemoCancel: () -> Unit = {},
+    onClickMemoDone: (String) -> Unit = {},
     onClickDelete: () -> Unit = {},
 ) {
-    NekiBothSidesActionBar(
-        modifier = modifier.fillMaxWidth(),
-        startContent = {
-            Row {
-                NekiIconButton(
-                    modifier = Modifier.padding(8.dp),
-                    onClick = onClickDownload,
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(NekiTheme.colorScheme.white),
+    ) {
+        AnimatedVisibility(
+            visible = memoMode != MemoMode.Closed,
+            enter = expandVertically(expandFrom = Alignment.Top),
+            exit = shrinkVertically(shrinkTowards = Alignment.Top),
+        ) {
+            MemoTextField(
+                memo = memo,
+                memoMode = memoMode,
+                onClickMemoMore = onClickMemoMore,
+                onClickMemoFold = onClickMemoFold,
+                onClickMemoText = onClickMemoText,
+                onClickMemoCancel = onClickMemoCancel,
+                onClickMemoDone = onClickMemoDone,
+            )
+        }
+
+        // 아이콘 바 (Editing 모드에서는 숨김)
+        if (memoMode != MemoMode.Editing) {
+            NekiBothSidesActionBar(
+                startContent = {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        NekiIconButton(
+                            modifier = Modifier.padding(8.dp),
+                            onClick = onClickDownload,
+                        ) {
+                            Icon(
+                                modifier = Modifier.size(28.dp),
+                                imageVector = ImageVector.vectorResource(R.drawable.icon_download),
+                                contentDescription = null,
+                                tint = NekiTheme.colorScheme.gray700,
+                            )
+                        }
+                        NekiIconButton(
+                            modifier = Modifier.padding(8.dp),
+                            onClick = onClickFavorite,
+                        ) {
+                            Icon(
+                                modifier = Modifier.size(28.dp),
+                                imageVector = ImageVector.vectorResource(
+                                    if (isFavorite) R.drawable.icon_favorite_filled
+                                    else R.drawable.icon_favorite_stroked,
+                                ),
+                                contentDescription = null,
+                                tint = if (isFavorite) NekiTheme.colorScheme.primary400
+                                else NekiTheme.colorScheme.gray700,
+                            )
+                        }
+                        NekiIconButton(
+                            modifier = Modifier.padding(8.dp),
+                            onClick = onClickMemo,
+                        ) {
+                            // TODO: ic_note 아이콘 리소스 추가 후 교체
+                            Icon(
+                                modifier = Modifier.size(28.dp),
+                                imageVector = ImageVector.vectorResource(R.drawable.icon_bookmark_stroked),
+                                contentDescription = null,
+                                tint = NekiTheme.colorScheme.gray700,
+                            )
+                        }
+                    }
+                },
+                endContent = {
+                    NekiIconButton(
+                        modifier = Modifier.padding(8.dp),
+                        onClick = onClickDelete,
+                    ) {
+                        Icon(
+                            modifier = Modifier.size(28.dp),
+                            imageVector = ImageVector.vectorResource(R.drawable.icon_trash),
+                            contentDescription = null,
+                            tint = NekiTheme.colorScheme.gray700,
+                        )
+                    }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun MemoTextField(
+    memo: String,
+    memoMode: MemoMode,
+    onClickMemoMore: () -> Unit,
+    onClickMemoFold: () -> Unit,
+    onClickMemoText: () -> Unit,
+    onClickMemoCancel: () -> Unit,
+    onClickMemoDone: (String) -> Unit,
+) {
+    val isEditing = memoMode == MemoMode.Editing
+    val isExpanded = memoMode == MemoMode.Expanded
+    val isPreview = memoMode == MemoMode.Preview
+    val memoState = remember { TextFieldState(initialText = memo) }
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(memo, memoMode) {
+        if (memoMode != MemoMode.Editing) {
+            memoState.edit { replace(0, length, memo) }
+        }
+    }
+
+    LaunchedEffect(memoMode) {
+        if (memoMode == MemoMode.Editing) {
+            memoState.edit { replace(0, length, memo) }
+            focusRequester.requestFocus()
+        }
+    }
+
+    val textFieldStyle = TextStyle(
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Medium,
+        lineHeight = 24.sp,
+        letterSpacing = (-0.32).sp,
+        color = NekiTheme.colorScheme.gray700,
+        lineHeightStyle = LineHeightStyle(
+            alignment = LineHeightStyle.Alignment.Center,
+            trim = LineHeightStyle.Trim.None,
+        ),
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(if (isEditing) NekiTheme.colorScheme.gray25 else NekiTheme.colorScheme.white),
+    ) {
+        HorizontalDivider(
+            modifier = Modifier.fillMaxWidth(),
+            thickness = 1.dp,
+            color = NekiTheme.colorScheme.gray75,
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(
+                    if (isPreview || isExpanded) Modifier.noRippleClickableSingle { onClickMemoText() } else Modifier,
+                )
+                .padding(
+                    start = if (isEditing) 20.dp else 12.dp,
+                    end = if (isEditing) 16.dp else 12.dp,
+                    top = if (isPreview) 8.dp else 16.dp,
+                    bottom = if (isEditing) 8.dp else 8.dp,
+                ),
+        ) {
+            if (isPreview) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Icon(
-                        modifier = Modifier.size(28.dp),
-                        imageVector = ImageVector.vectorResource(R.drawable.icon_download),
-                        contentDescription = null,
-                        tint = NekiTheme.colorScheme.gray700,
-                    )
-                }
-                NekiIconButton(
-                    modifier = Modifier.padding(8.dp),
-                    onClick = onClickFavorite,
-                ) {
-                    Icon(
-                        modifier = Modifier.size(28.dp),
-                        imageVector = ImageVector.vectorResource(
-                            if (isFavorite) R.drawable.icon_favorite_filled
-                            else R.drawable.icon_favorite_stroked,
+                    Text(
+                        text = memo.ifEmpty { "메모 없음" },
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(horizontal = 8.dp),
+                        style = textFieldStyle.copy(
+                            color = if (memo.isEmpty()) NekiTheme.colorScheme.gray300
+                            else NekiTheme.colorScheme.gray700,
                         ),
-                        contentDescription = null,
-                        tint = if (isFavorite) NekiTheme.colorScheme.primary400
-                        else NekiTheme.colorScheme.gray700,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = "더보기",
+                        modifier = Modifier
+                            .noRippleClickableSingle { onClickMemoMore() }
+                            .padding(8.dp),
+                        style = TextStyle(
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Medium,
+                            lineHeight = 24.sp,
+                            letterSpacing = (-0.32).sp,
+                            color = NekiTheme.colorScheme.gray200,
+                        ),
                     )
                 }
-            }
-        },
-        endContent = {
-            NekiIconButton(
-                modifier = Modifier.padding(8.dp),
-                onClick = onClickDelete,
-            ) {
-                Icon(
-                    modifier = Modifier.size(28.dp),
-                    imageVector = ImageVector.vectorResource(R.drawable.icon_trash),
-                    contentDescription = null,
-                    tint = NekiTheme.colorScheme.gray700,
+            } else {
+                BasicTextField(
+                    state = memoState,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(if (isExpanded) Modifier.padding(horizontal = 8.dp) else Modifier)
+                        .focusRequester(focusRequester)
+                        .onFocusChanged {
+                            if (it.isFocused && isExpanded) onClickMemoText()
+                        },
+                    textStyle = textFieldStyle,
+                    readOnly = isExpanded,
+                    inputTransformation = InputTransformation.maxLength(100),
+                    cursorBrush = SolidColor(
+                        if (isEditing) NekiTheme.colorScheme.gray900 else Color.Transparent,
+                    ),
+                    decorator = { innerTextField ->
+                        Box {
+                            if (memoState.text.isEmpty()) {
+                                Text(
+                                    text = if (isEditing) "자유롭게 메모를 입력해주세요. (최대 100자)" else "메모 없음",
+                                    style = textFieldStyle.copy(color = NekiTheme.colorScheme.gray300),
+                                )
+                            }
+                            innerTextField()
+                        }
+                    },
                 )
             }
-        },
-    )
+
+            // Expanded: 메모 접기
+            if (isExpanded) {
+                Text(
+                    text = "메모 접기",
+                    modifier = Modifier
+                        .align(Alignment.End)
+                        .noRippleClickableSingle { onClickMemoFold() }
+                        .padding(start = 8.dp, end = 8.dp, bottom = 8.dp),
+                    style = TextStyle(
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Medium,
+                        lineHeight = 24.sp,
+                        letterSpacing = (-0.32).sp,
+                        color = NekiTheme.colorScheme.gray200,
+                    ),
+                )
+            }
+
+            // Editing: 카운터 + 전체지우기 + 취소/완료
+            if (isEditing) {
+                val charCount = memoState.text.length
+                val hasText = charCount > 0
+
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = "$charCount/100",
+                            style = TextStyle(
+                                fontSize = 12.sp,
+                                lineHeight = 16.sp,
+                                letterSpacing = (-0.24).sp,
+                                color = NekiTheme.colorScheme.gray300,
+                            ),
+                        )
+                        Text(
+                            text = "전체 지우기",
+                            modifier = Modifier
+                                .noRippleClickableSingle { memoState.edit { replace(0, length, "") } }
+                                .padding(8.dp),
+                            style = TextStyle(
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Medium,
+                                lineHeight = 16.sp,
+                                letterSpacing = (-0.24).sp,
+                                color = if (hasText) NekiTheme.colorScheme.gray600
+                                else NekiTheme.colorScheme.gray200,
+                            ),
+                        )
+                    }
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "취소",
+                            modifier = Modifier
+                                .noRippleClickableSingle { onClickMemoCancel() }
+                                .padding(vertical = 10.dp),
+                            style = TextStyle(
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                lineHeight = 24.sp,
+                                letterSpacing = (-0.32).sp,
+                                color = NekiTheme.colorScheme.gray800,
+                            ),
+                        )
+                        Text(
+                            text = "완료",
+                            modifier = Modifier
+                                .noRippleClickableSingle { onClickMemoDone(memoState.text.toString()) }
+                                .padding(vertical = 10.dp),
+                            style = TextStyle(
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                lineHeight = 24.sp,
+                                letterSpacing = (-0.32).sp,
+                                color = NekiTheme.colorScheme.primary500,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    }
 }
 
 @ComponentPreview
 @Composable
-private fun PhotoDetailActionBarNotFavoritePreview() {
+private fun PhotoDetailActionBarClosedPreview() {
     NekiTheme {
         PhotoDetailActionBar(
             isFavorite = false,
+            memo = "",
+            memoMode = MemoMode.Closed,
         )
     }
 }
 
 @ComponentPreview
 @Composable
-private fun PhotoDetailActionBarFavoritePreview() {
+private fun PhotoDetailActionBarPreviewPreview() {
+    NekiTheme {
+        PhotoDetailActionBar(
+            isFavorite = false,
+            memo = "재밌었던 날인데 메모가 길어서 한 줄에 다 안 들어갈 수도 있어요",
+            memoMode = MemoMode.Preview,
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun PhotoDetailActionBarExpandedPreview() {
     NekiTheme {
         PhotoDetailActionBar(
             isFavorite = true,
+            memo = "재밌었던 날인데 메모가 길어서 한 줄에 다 안 들어갈 수도 있어요",
+            memoMode = MemoMode.Expanded,
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun PhotoDetailActionBarEditingPreview() {
+    NekiTheme {
+        PhotoDetailActionBar(
+            isFavorite = true,
+            memo = "재밌었던 날",
+            memoMode = MemoMode.Editing,
         )
     }
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailActionBar.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailActionBar.kt
@@ -1,365 +1,87 @@
 package com.neki.android.feature.archive.impl.photo_detail.component
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.input.InputTransformation
-import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.maxLength
-import androidx.compose.ui.graphics.Color
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.neki.android.core.designsystem.ComponentPreview
 import com.neki.android.core.designsystem.R
 import com.neki.android.core.designsystem.actionbar.NekiBothSidesActionBar
 import com.neki.android.core.designsystem.button.NekiIconButton
-import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
-import com.neki.android.feature.archive.impl.photo_detail.MemoMode
 
 @Composable
 internal fun PhotoDetailActionBar(
     isFavorite: Boolean,
-    memo: String,
-    memoMode: MemoMode,
     modifier: Modifier = Modifier,
     onClickDownload: () -> Unit = {},
     onClickFavorite: () -> Unit = {},
     onClickMemo: () -> Unit = {},
-    onClickMemoMore: () -> Unit = {},
-    onClickMemoText: () -> Unit = {},
-    onClickMemoFold: () -> Unit = {},
-    onClickMemoCancel: () -> Unit = {},
-    onClickMemoDone: (String) -> Unit = {},
     onClickDelete: () -> Unit = {},
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(NekiTheme.colorScheme.white),
-    ) {
-        AnimatedVisibility(
-            visible = memoMode != MemoMode.Closed,
-            enter = expandVertically(expandFrom = Alignment.Top),
-            exit = shrinkVertically(shrinkTowards = Alignment.Top),
-        ) {
-            MemoTextField(
-                memo = memo,
-                memoMode = memoMode,
-                onClickMemoMore = onClickMemoMore,
-                onClickMemoFold = onClickMemoFold,
-                onClickMemoText = onClickMemoText,
-                onClickMemoCancel = onClickMemoCancel,
-                onClickMemoDone = onClickMemoDone,
-            )
-        }
-
-        // 아이콘 바 (Editing 모드에서는 숨김)
-        if (memoMode != MemoMode.Editing) {
-            NekiBothSidesActionBar(
-                startContent = {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        NekiIconButton(
-                            modifier = Modifier.padding(8.dp),
-                            onClick = onClickDownload,
-                        ) {
-                            Icon(
-                                modifier = Modifier.size(28.dp),
-                                imageVector = ImageVector.vectorResource(R.drawable.icon_download),
-                                contentDescription = null,
-                                tint = NekiTheme.colorScheme.gray700,
-                            )
-                        }
-                        NekiIconButton(
-                            modifier = Modifier.padding(8.dp),
-                            onClick = onClickFavorite,
-                        ) {
-                            Icon(
-                                modifier = Modifier.size(28.dp),
-                                imageVector = ImageVector.vectorResource(
-                                    if (isFavorite) R.drawable.icon_favorite_filled
-                                    else R.drawable.icon_favorite_stroked,
-                                ),
-                                contentDescription = null,
-                                tint = if (isFavorite) NekiTheme.colorScheme.primary400
-                                else NekiTheme.colorScheme.gray700,
-                            )
-                        }
-                        NekiIconButton(
-                            modifier = Modifier.padding(8.dp),
-                            onClick = onClickMemo,
-                        ) {
-                            // TODO: ic_note 아이콘 리소스 추가 후 교체
-                            Icon(
-                                modifier = Modifier.size(28.dp),
-                                imageVector = ImageVector.vectorResource(R.drawable.icon_bookmark_stroked),
-                                contentDescription = null,
-                                tint = NekiTheme.colorScheme.gray700,
-                            )
-                        }
-                    }
-                },
-                endContent = {
-                    NekiIconButton(
-                        modifier = Modifier.padding(8.dp),
-                        onClick = onClickDelete,
-                    ) {
-                        Icon(
-                            modifier = Modifier.size(28.dp),
-                            imageVector = ImageVector.vectorResource(R.drawable.icon_trash),
-                            contentDescription = null,
-                            tint = NekiTheme.colorScheme.gray700,
-                        )
-                    }
-                },
-            )
-        }
-    }
-}
-
-@Composable
-private fun MemoTextField(
-    memo: String,
-    memoMode: MemoMode,
-    onClickMemoMore: () -> Unit,
-    onClickMemoFold: () -> Unit,
-    onClickMemoText: () -> Unit,
-    onClickMemoCancel: () -> Unit,
-    onClickMemoDone: (String) -> Unit,
-) {
-    val isEditing = memoMode == MemoMode.Editing
-    val isExpanded = memoMode == MemoMode.Expanded
-    val isPreview = memoMode == MemoMode.Preview
-    val memoState = remember { TextFieldState(initialText = memo) }
-    val focusRequester = remember { FocusRequester() }
-
-    LaunchedEffect(memo, memoMode) {
-        if (memoMode != MemoMode.Editing) {
-            memoState.edit { replace(0, length, memo) }
-        }
-    }
-
-    LaunchedEffect(memoMode) {
-        if (memoMode == MemoMode.Editing) {
-            memoState.edit { replace(0, length, memo) }
-            focusRequester.requestFocus()
-        }
-    }
-
-    val textFieldStyle = TextStyle(
-        fontSize = 16.sp,
-        fontWeight = FontWeight.Medium,
-        lineHeight = 24.sp,
-        letterSpacing = (-0.32).sp,
-        color = NekiTheme.colorScheme.gray700,
-        lineHeightStyle = LineHeightStyle(
-            alignment = LineHeightStyle.Alignment.Center,
-            trim = LineHeightStyle.Trim.None,
-        ),
+    NekiBothSidesActionBar(
+        modifier = modifier,
+        startContent = {
+            Row(
+                modifier = Modifier.padding(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                NekiIconButton(
+                    onClick = onClickDownload,
+                ) {
+                    Icon(
+                        modifier = Modifier.size(28.dp),
+                        imageVector = ImageVector.vectorResource(R.drawable.icon_download),
+                        contentDescription = null,
+                        tint = NekiTheme.colorScheme.gray700,
+                    )
+                }
+                NekiIconButton(
+                    onClick = onClickFavorite,
+                ) {
+                    Icon(
+                        modifier = Modifier.size(28.dp),
+                        imageVector = ImageVector.vectorResource(
+                            if (isFavorite) R.drawable.icon_favorite_filled
+                            else R.drawable.icon_favorite_stroked,
+                        ),
+                        contentDescription = null,
+                        tint = if (isFavorite) NekiTheme.colorScheme.primary400
+                        else NekiTheme.colorScheme.gray700,
+                    )
+                }
+                NekiIconButton(
+                    onClick = onClickMemo,
+                ) {
+                    Icon(
+                        modifier = Modifier.size(28.dp),
+                        imageVector = ImageVector.vectorResource(R.drawable.icon_memo),
+                        contentDescription = null,
+                        tint = NekiTheme.colorScheme.gray700,
+                    )
+                }
+            }
+        },
+        endContent = {
+            NekiIconButton(
+                modifier = Modifier.padding(8.dp),
+                onClick = onClickDelete,
+            ) {
+                Icon(
+                    modifier = Modifier.size(28.dp),
+                    imageVector = ImageVector.vectorResource(R.drawable.icon_trash),
+                    contentDescription = null,
+                    tint = NekiTheme.colorScheme.gray700,
+                )
+            }
+        },
     )
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(if (isEditing) NekiTheme.colorScheme.gray25 else NekiTheme.colorScheme.white),
-    ) {
-        HorizontalDivider(
-            modifier = Modifier.fillMaxWidth(),
-            thickness = 1.dp,
-            color = NekiTheme.colorScheme.gray75,
-        )
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .then(
-                    if (isPreview || isExpanded) Modifier.noRippleClickableSingle { onClickMemoText() } else Modifier,
-                )
-                .padding(
-                    start = if (isEditing) 20.dp else 12.dp,
-                    end = if (isEditing) 16.dp else 12.dp,
-                    top = if (isPreview) 8.dp else 16.dp,
-                    bottom = if (isEditing) 8.dp else 8.dp,
-                ),
-        ) {
-            if (isPreview) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = memo.ifEmpty { "메모 없음" },
-                        modifier = Modifier
-                            .weight(1f)
-                            .padding(horizontal = 8.dp),
-                        style = textFieldStyle.copy(
-                            color = if (memo.isEmpty()) NekiTheme.colorScheme.gray300
-                            else NekiTheme.colorScheme.gray700,
-                        ),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(
-                        text = "더보기",
-                        modifier = Modifier
-                            .noRippleClickableSingle { onClickMemoMore() }
-                            .padding(8.dp),
-                        style = TextStyle(
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.Medium,
-                            lineHeight = 24.sp,
-                            letterSpacing = (-0.32).sp,
-                            color = NekiTheme.colorScheme.gray200,
-                        ),
-                    )
-                }
-            } else {
-                BasicTextField(
-                    state = memoState,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .then(if (isExpanded) Modifier.padding(horizontal = 8.dp) else Modifier)
-                        .focusRequester(focusRequester)
-                        .onFocusChanged {
-                            if (it.isFocused && isExpanded) onClickMemoText()
-                        },
-                    textStyle = textFieldStyle,
-                    readOnly = isExpanded,
-                    inputTransformation = InputTransformation.maxLength(100),
-                    cursorBrush = SolidColor(
-                        if (isEditing) NekiTheme.colorScheme.gray900 else Color.Transparent,
-                    ),
-                    decorator = { innerTextField ->
-                        Box {
-                            if (memoState.text.isEmpty()) {
-                                Text(
-                                    text = if (isEditing) "자유롭게 메모를 입력해주세요. (최대 100자)" else "메모 없음",
-                                    style = textFieldStyle.copy(color = NekiTheme.colorScheme.gray300),
-                                )
-                            }
-                            innerTextField()
-                        }
-                    },
-                )
-            }
-
-            // Expanded: 메모 접기
-            if (isExpanded) {
-                Text(
-                    text = "메모 접기",
-                    modifier = Modifier
-                        .align(Alignment.End)
-                        .noRippleClickableSingle { onClickMemoFold() }
-                        .padding(start = 8.dp, end = 8.dp, bottom = 8.dp),
-                    style = TextStyle(
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Medium,
-                        lineHeight = 24.sp,
-                        letterSpacing = (-0.32).sp,
-                        color = NekiTheme.colorScheme.gray200,
-                    ),
-                )
-            }
-
-            // Editing: 카운터 + 전체지우기 + 취소/완료
-            if (isEditing) {
-                val charCount = memoState.text.length
-                val hasText = charCount > 0
-
-                Spacer(modifier = Modifier.height(8.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = "$charCount/100",
-                            style = TextStyle(
-                                fontSize = 12.sp,
-                                lineHeight = 16.sp,
-                                letterSpacing = (-0.24).sp,
-                                color = NekiTheme.colorScheme.gray300,
-                            ),
-                        )
-                        Text(
-                            text = "전체 지우기",
-                            modifier = Modifier
-                                .noRippleClickableSingle { memoState.edit { replace(0, length, "") } }
-                                .padding(8.dp),
-                            style = TextStyle(
-                                fontSize = 12.sp,
-                                fontWeight = FontWeight.Medium,
-                                lineHeight = 16.sp,
-                                letterSpacing = (-0.24).sp,
-                                color = if (hasText) NekiTheme.colorScheme.gray600
-                                else NekiTheme.colorScheme.gray200,
-                            ),
-                        )
-                    }
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = "취소",
-                            modifier = Modifier
-                                .noRippleClickableSingle { onClickMemoCancel() }
-                                .padding(vertical = 10.dp),
-                            style = TextStyle(
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.SemiBold,
-                                lineHeight = 24.sp,
-                                letterSpacing = (-0.32).sp,
-                                color = NekiTheme.colorScheme.gray800,
-                            ),
-                        )
-                        Text(
-                            text = "완료",
-                            modifier = Modifier
-                                .noRippleClickableSingle { onClickMemoDone(memoState.text.toString()) }
-                                .padding(vertical = 10.dp),
-                            style = TextStyle(
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.SemiBold,
-                                lineHeight = 24.sp,
-                                letterSpacing = (-0.32).sp,
-                                color = NekiTheme.colorScheme.primary500,
-                            ),
-                        )
-                    }
-                }
-            }
-        }
-    }
 }
 
 @ComponentPreview
@@ -368,44 +90,16 @@ private fun PhotoDetailActionBarClosedPreview() {
     NekiTheme {
         PhotoDetailActionBar(
             isFavorite = false,
-            memo = "",
-            memoMode = MemoMode.Closed,
         )
     }
 }
 
 @ComponentPreview
 @Composable
-private fun PhotoDetailActionBarPreviewPreview() {
-    NekiTheme {
-        PhotoDetailActionBar(
-            isFavorite = false,
-            memo = "재밌었던 날인데 메모가 길어서 한 줄에 다 안 들어갈 수도 있어요",
-            memoMode = MemoMode.Preview,
-        )
-    }
-}
-
-@ComponentPreview
-@Composable
-private fun PhotoDetailActionBarExpandedPreview() {
+private fun PhotoDetailActionBarMemoActivePreview() {
     NekiTheme {
         PhotoDetailActionBar(
             isFavorite = true,
-            memo = "재밌었던 날인데 메모가 길어서 한 줄에 다 안 들어갈 수도 있어요",
-            memoMode = MemoMode.Expanded,
-        )
-    }
-}
-
-@ComponentPreview
-@Composable
-private fun PhotoDetailActionBarEditingPreview() {
-    NekiTheme {
-        PhotoDetailActionBar(
-            isFavorite = true,
-            memo = "재밌었던 날",
-            memoMode = MemoMode.Editing,
         )
     }
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailImageItem.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailImageItem.kt
@@ -1,0 +1,105 @@
+package com.neki.android.feature.archive.impl.photo_detail.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import coil3.compose.AsyncImage
+import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
+import com.neki.android.feature.archive.impl.photo_detail.MemoMode
+
+@Composable
+internal fun PhotoDetailImageItem(
+    imageUrl: String?,
+    memo: String,
+    memoMode: MemoMode,
+    isScrollInProgress: Boolean,
+    isTapEnabled: Boolean,
+    onClickLeft: () -> Unit,
+    onClickRight: () -> Unit,
+    onClickMemoMore: () -> Unit,
+    onClickMemoText: () -> Unit,
+    onClickMemoFold: () -> Unit,
+    onClickMemoCancel: () -> Unit,
+    onClickMemoDone: (String) -> Unit,
+    onMemoTextChanged: (String) -> Unit,
+) {
+    val isMemoActive = memoMode == MemoMode.Expanded || memoMode == MemoMode.Editing
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        AsyncImage(
+            modifier = Modifier.fillMaxSize(),
+            model = imageUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Fit,
+        )
+
+        if (isTapEnabled) {
+            Row(modifier = Modifier.matchParentSize()) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .noRippleClickableSingle {
+                            if (!isScrollInProgress) onClickLeft()
+                        },
+                )
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .noRippleClickableSingle {
+                            if (!isScrollInProgress) onClickRight()
+                        },
+                )
+            }
+        }
+
+        // dim 오버레이
+        AnimatedVisibility(
+            visible = isMemoActive,
+            enter = fadeIn(),
+            exit = fadeOut(),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0x80202227))
+                    .noRippleClickableSingle { onClickMemoFold() },
+            )
+        }
+
+        // 메모 텍스트 영역
+        AnimatedVisibility(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .imePadding(),
+            visible = memoMode != MemoMode.Closed,
+            enter = expandVertically(expandFrom = Alignment.Top),
+            exit = shrinkVertically(shrinkTowards = Alignment.Top),
+        ) {
+            MemoTextField(
+                memo = memo,
+                memoMode = memoMode,
+                onClickMemoMore = onClickMemoMore,
+                onClickMemoText = onClickMemoText,
+                onClickMemoFold = onClickMemoFold,
+                onClickMemoCancel = onClickMemoCancel,
+                onClickMemoDone = onClickMemoDone,
+                onMemoTextChanged = onMemoTextChanged,
+            )
+        }
+    }
+}

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailImageItem.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailImageItem.kt
@@ -8,10 +8,14 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -94,7 +98,12 @@ internal fun PhotoDetailImageItem(
         AnimatedVisibility(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .imePadding(),
+                .then(
+                    if (memoMode == MemoMode.Editing) Modifier.imePadding()
+                    else Modifier.windowInsetsPadding(
+                        WindowInsets.ime.exclude(WindowInsets(bottom = actionBarHeight)),
+                    ),
+                ),
             visible = memoMode != MemoMode.Closed,
             enter = expandVertically(expandFrom = Alignment.Top),
             exit = shrinkVertically(shrinkTowards = Alignment.Top),

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailImageItem.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailImageItem.kt
@@ -11,11 +11,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
 import com.neki.android.feature.archive.impl.photo_detail.MemoMode
@@ -25,6 +28,7 @@ internal fun PhotoDetailImageItem(
     imageUrl: String?,
     memo: String,
     memoMode: MemoMode,
+    actionBarHeight: Dp = 0.dp,
     isScrollInProgress: Boolean,
     isTapEnabled: Boolean,
     onClickLeft: () -> Unit,
@@ -37,10 +41,15 @@ internal fun PhotoDetailImageItem(
     onMemoTextChanged: (String) -> Unit,
 ) {
     val isMemoActive = memoMode == MemoMode.Expanded || memoMode == MemoMode.Editing
+    val bottomPadding = if (memoMode == MemoMode.Editing) actionBarHeight else 0.dp
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+    ) {
         AsyncImage(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = bottomPadding),
             model = imageUrl,
             contentDescription = null,
             contentScale = ContentScale.Fit,

--- a/feature/pose/impl/build.gradle.kts
+++ b/feature/pose/impl/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
 
     implementation(libs.kotlinx.collections.immutable)
     implementation(libs.androidx.paging.compose)
+    implementation(libs.zoomable)
 }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailScreen.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailScreen.kt
@@ -3,7 +3,6 @@ package com.neki.android.feature.pose.impl.detail
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailScreen.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.neki.android.feature.pose.impl.detail
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,10 +9,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import net.engawapg.lib.zoomable.rememberZoomState
+import net.engawapg.lib.zoomable.zoomable
 import com.neki.android.core.designsystem.DevicePreview
 import com.neki.android.core.designsystem.topbar.BackTitleTopBar
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
@@ -66,15 +70,23 @@ internal fun PoseDetailScreen(
             title = "포즈 상세",
             onBack = { onIntent(PoseDetailIntent.ClickBackIcon) },
         )
-        AsyncImage(
-            model = uiState.pose.poseImageUrl,
-            contentDescription = null,
+        Box(
             modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-            contentScale = ContentScale.Fit,
-            alignment = Alignment.Center,
-        )
+                .weight(1f)
+                .clipToBounds(),
+        ) {
+            val zoomState = rememberZoomState()
+            AsyncImage(
+                model = uiState.pose.poseImageUrl,
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .zoomable(zoomState),
+                contentScale = ContentScale.Fit,
+                alignment = Alignment.Center,
+                onSuccess = { state -> zoomState.setContentSize(state.painter.intrinsicSize) },
+            )
+        }
         PoseActionBar(
             isBookmarked = uiState.pose.isBookmarked,
             onClickBookmark = { onIntent(PoseDetailIntent.ClickBookmarkIcon) },

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ detekt = "1.23.8"
 barcodeScanning = "17.3.0"
 kakao = "2.23.1"
 coil = "3.3.0"
+zoomable = "2.11.1"
 haze = "1.7.1"
 lottie = "6.7.1"
 exifinterface = "1.4.2"
@@ -107,6 +108,8 @@ kakao-user = { module = "com.kakao.sdk:v2-user", version.ref = "kakao" }
 
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+
+zoomable = { group = "net.engawapg.lib", name = "zoomable", version.ref = "zoomable" }
 
 haze = { group = "dev.chrisbanes.haze", name = "haze", version.ref = "haze" }
 haze-materials = { group = "dev.chrisbanes.haze", name = "haze-materials", version.ref = "haze" }


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #161

## 📙 작업 설명
- `ResultEventBus`의 Channel 1:1 소비 구조에서 송신 화면이 자기 이벤트를 소비하는 문제 해결
- `ArchiveResult`를 화면별 `data object`로 분리하여 Channel 키 분리
  - `PhotoDetailResult`, `AlbumDetailResult`, `AllPhotoResult`, `AllAlbumResult`, `PhotoUploadedResult`
- 수신 측은 세부 이벤트 없이 관련 데이터를 통째로 갱신하는 방식으로 단순화
- `ArchiveMain`의 `RefreshArchiveMain`이 사진뿐 아니라 즐겨찾기 + 앨범까지 병렬 갱신하도록 변경


## 🧪 테스트 내역 (선택)

**PhotoDetail → ArchiveMain**
- [x] 즐겨찾기 토글 → 뒤로 → ArchiveMain 갱신
- [x] 사진 삭제 → 뒤로 → ArchiveMain 갱신

**PhotoDetail → AllPhoto**
- [x] 즐겨찾기 토글 → 뒤로 → AllPhoto 갱신
- [x] 사진 삭제 → 뒤로 → AllPhoto 갱신

**PhotoDetail → AlbumDetail**
- [x] 즐겨찾기 토글 → 뒤로 → AlbumDetail 갱신
- [x] 사진 삭제 → 뒤로 → AlbumDetail 갱신

**AlbumDetail → ArchiveMain**
- [x] 사진 업로드 → 뒤로 → ArchiveMain 갱신
- [x] 사진 삭제 → 뒤로 → ArchiveMain 갱신
- [x] 앨범 이름 변경 → 뒤로 → ArchiveMain 갱신

**AlbumDetail → AllAlbum**
- [x] 앨범 이름 변경 → 뒤로 → AllAlbum 갱신
- [x] 사진 업로드 → 뒤로 → AllAlbum 갱신
- [x] 사진 삭제 → 뒤로 → AllAlbum 갱신

**AllPhoto → ArchiveMain**
- [x] 즐겨찾기 토글 → 뒤로 → ArchiveMain 갱신
- [x] 사진 삭제 → 뒤로 → ArchiveMain 갱신

**AllAlbum → ArchiveMain**
- [x] 앨범 생성 → 뒤로 → ArchiveMain 갱신
- [x] 앨범 삭제 → 뒤로 → ArchiveMain 갱신

## 📸 스크린샷 또는 시연 영상 (선택)

## 💬 추가 설명 or 리뷰 포인트 (선택)
- 기존 문제: `ResultEventBus`가 Channel 기반 1:1 소비 구조라, 모든 화면이 동일한 `ArchiveResult` 타입을 사용하면 송신 화면의 `ResultEffect`가 자기가 보낸 이벤트를 먼저 소비해 상위 화면에 전달되지 않는 문제가 있었습니다.
  - 예: AllPhoto에서 즐겨찾기 토글 시 `ArchiveResult.FavoriteChanged`를 송신 → AllPhoto 자신의 `ResultEffect<ArchiveResult>`가 먼저 소비 → ArchiveMain에 도달하지 않음
- 현재는 세부 이벤트 없이 `data object`만 방출하고 있으며, 추후 기능 추가 시 별도 이슈로 세부 Result 이벤트를 추가할 예정입니다.
  - 예: `PhotoDetailResult` → `PhotoDetailResult.FavoriteChanged(photoId, isFavorite)`, `PhotoDetailResult.PhotoDeleted(photoIds)` 등

---
- #167 머지 후 릴레이 Result 전달 기능을 추가한 뒤 진행하려고 합니다.

Q. 아카이빙 모듈 내에 각 화면들에 대한 역할이 점점 커져가서, 이 화면들을 모듈로 나누는 편이 나을까요?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사진 상세에 메모 보기/확장/편집/저장 UI와 메모 아이콘을 추가했습니다.
  * 사진·포즈 상세에서 핀치-줌(확대/축소) 지원을 추가했습니다.
* **개선**
  * 화면 간 결과 통지 흐름을 통합하고 중복 알림을 억제해 변경 반영이 일관되게 이루어집니다.
  * 페이저·탭·스크롤 상호작용과 페이징 인덱스 처리 방식이 더 안정적이고 직관적으로 동작합니다.
* **리팩토링**
  * 메모 저장/동기화 관련 API 및 모델을 추가해 메모를 서버에 보관할 수 있습니다.
* **잡업(Chores)**
  * 메모 아이콘 리소스와 줌 라이브러리 의존성이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->