### PR TITLE
[feat] #167 MviIntentStore init 기반 초기 데이터 로드 방식 추가

### DIFF
--- a/core/ui/src/main/java/com/neki/android/core/ui/MviIntentStore.kt
+++ b/core/ui/src/main/java/com/neki/android/core/ui/MviIntentStore.kt
@@ -8,6 +8,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -22,7 +23,7 @@ interface MviIntentStore<STATE, INTENT, EFFECT> {
 
 class MviIntentStoreImpl<STATE, INTENT, EFFECT>(
     initialState: STATE,
-    initialFetchData: () -> Unit,
+    initialFetchData: (() -> Unit)?,
     private val coroutineScope: CoroutineScope,
     private val onIntent: (
         intent: INTENT,
@@ -32,13 +33,18 @@ class MviIntentStoreImpl<STATE, INTENT, EFFECT>(
     ) -> Unit,
 ) : MviIntentStore<STATE, INTENT, EFFECT> {
     private val _uiState = MutableStateFlow(initialState)
-    override val uiState: StateFlow<STATE> = _uiState
-        .onStart { initialFetchData() }
-        .stateIn(
-            scope = coroutineScope,
-            started = SharingStarted.WhileSubscribed(5000L),
-            initialValue = initialState,
-        )
+    override val uiState: StateFlow<STATE> =
+        if (initialFetchData != null) {
+            _uiState
+                .onStart { initialFetchData() }
+                .stateIn(
+                    scope = coroutineScope,
+                    started = SharingStarted.WhileSubscribed(5000L),
+                    initialValue = initialState,
+                )
+        } else {
+            _uiState.asStateFlow()
+        }
     private val _sideEffects = Channel<EFFECT>(Channel.BUFFERED)
     override val sideEffects: Flow<EFFECT> = _sideEffects.receiveAsFlow()
     private fun setState(reduce: STATE.() -> STATE) {
@@ -62,7 +68,7 @@ class MviIntentStoreImpl<STATE, INTENT, EFFECT>(
 fun <STATE, INTENT, EFFECT> ViewModel.mviIntentStore(
     initialState: STATE,
     onIntent: (INTENT, STATE, (STATE.() -> STATE) -> Unit, (EFFECT) -> Unit) -> Unit,
-    initialFetchData: () -> Unit = {},
+    initialFetchData: (() -> Unit)? = null,
 ): MviIntentStore<STATE, INTENT, EFFECT> = MviIntentStoreImpl(
     initialState = initialState,
     coroutineScope = viewModelScope,

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album/AllAlbumViewModel.kt
@@ -28,8 +28,11 @@ class AllAlbumViewModel @Inject constructor(
         mviIntentStore(
             initialState = AllAlbumState(),
             onIntent = ::onIntent,
-            initialFetchData = { store.onIntent(AllAlbumIntent.EnterAllAlbumScreen) },
         )
+
+    init {
+        store.onIntent(AllAlbumIntent.EnterAllAlbumScreen)
+    }
 
     private fun onIntent(
         intent: AllAlbumIntent,

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
@@ -32,10 +32,13 @@ class ArchiveMainViewModel @Inject constructor(
         mviIntentStore(
             initialState = ArchiveMainState(),
             onIntent = ::onIntent,
-            initialFetchData = { store.onIntent(ArchiveMainIntent.EnterArchiveMainScreen) },
         )
-
     private var fetchJob: Job? = null
+
+    init {
+        store.onIntent(ArchiveMainIntent.EnterArchiveMainScreen)
+    }
+
     private fun onIntent(
         intent: ArchiveMainIntent,
         state: ArchiveMainState,

--- a/feature/auth/impl/src/main/kotlin/com/neki/android/feature/auth/impl/term/TermViewModel.kt
+++ b/feature/auth/impl/src/main/kotlin/com/neki/android/feature/auth/impl/term/TermViewModel.kt
@@ -22,8 +22,11 @@ class TermViewModel @Inject constructor(
         mviIntentStore(
             initialState = TermState(),
             onIntent = ::onIntent,
-            initialFetchData = { store.onIntent(TermIntent.EnterTermScreen) },
         )
+
+    init {
+        store.onIntent(TermIntent.EnterTermScreen)
+    }
 
     private fun onIntent(
         intent: TermIntent,

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/main/MyPageViewModel.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/main/MyPageViewModel.kt
@@ -29,8 +29,11 @@ internal class MyPageViewModel @Inject constructor(
         mviIntentStore(
             initialState = MyPageState(),
             onIntent = ::onIntent,
-            initialFetchData = { store.onIntent(MyPageIntent.EnterMypageScreen) },
         )
+
+    init {
+        store.onIntent(MyPageIntent.EnterMypageScreen)
+    }
 
     private fun onIntent(
         intent: MyPageIntent,

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/album/UploadAlbumViewModel.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/album/UploadAlbumViewModel.kt
@@ -44,8 +44,11 @@ class UploadAlbumViewModel @AssistedInject constructor(
                 selectedUris = uriStrings.map { it.toUri() }.toImmutableList(),
             ),
             onIntent = ::onIntent,
-            initialFetchData = { store.onIntent(UploadAlbumIntent.EnterUploadAlbumScreen) },
         )
+
+    init {
+        store.onIntent(UploadAlbumIntent.EnterUploadAlbumScreen)
+    }
 
     private fun onIntent(
         intent: UploadAlbumIntent,

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailViewModel.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailViewModel.kt
@@ -36,10 +36,10 @@ class PoseDetailViewModel @AssistedInject constructor(
         mviIntentStore(
             initialState = PoseDetailState(),
             onIntent = ::onIntent,
-            initialFetchData = { store.onIntent(PoseDetailIntent.EnterPoseDetailScreen) },
         )
 
     init {
+        store.onIntent(PoseDetailIntent.EnterPoseDetailScreen)
         viewModelScope.launch {
             bookmarkRequests
                 .debounce(500)

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseViewModel.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseViewModel.kt
@@ -42,8 +42,11 @@ internal class RandomPoseViewModel @AssistedInject constructor(
         mviIntentStore(
             initialState = RandomPoseState(),
             onIntent = ::onIntent,
-            initialFetchData = { store.onIntent(RandomPoseIntent.EnterRandomPoseScreen) },
         )
+
+    init {
+        store.onIntent(RandomPoseIntent.EnterRandomPoseScreen)
+    }
 
     private fun onIntent(
         intent: RandomPoseIntent,


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #167

## 📙 작업 설명
- MviIntentStoreImpl의 initialFetchData를 nullable로 변경하여 null일 경우 asStateFlow(), non-null일 경우 기존 onStart + stateIn 분기
- 재로딩이 불필요한 ViewModel 7개를 init 블록 기반 초기 데이터 로드로 전환
  - ArchiveMainViewModel, AllAlbumViewModel, PoseDetailViewModel, RandomPoseViewModel, MyPageViewModel, TermViewModel, UploadAlbumViewModel
- MapViewModel은 탭 전환 재방문 빈도가 높아 기존 onStart 방식 유지

## 💬 추가 설명 or 리뷰 포인트 (선택)
- initialFetchData를 넘기지 않는 기존 ViewModel 8개는 기본값이 null로 바뀌면서 onStart 래핑 대신 asStateFlow()로 전환되지만 동작 차이 없음
- #166 PR에서 UploadAlbumViewModel에 result 처리를 추가할 계획입니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 앱의 초기 데이터 로드 메커니즘을 개선하여 더욱 유연한 초기화 패턴을 지원하도록 변경했습니다. 기능상 변화는 없으며 모든 화면은 이전과 동일하게 로드됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->