### PR TITLE
[feat] #170 QR 스캔 실패 케이스 Discord Webhook 로깅

### DIFF
--- a/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/DiscordWebhookRepository.kt
+++ b/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/DiscordWebhookRepository.kt
@@ -1,0 +1,6 @@
+package com.neki.android.core.dataapi.repository
+
+interface DiscordWebhookRepository {
+    suspend fun logUnsupportedBrandQR(scannedUrl: String)
+    suspend fun logWebViewExitWithoutImage(scannedUrl: String)
+}

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -21,6 +21,10 @@ android {
         buildConfig = true
     }
 
+    defaultConfig {
+        buildConfigField("String", "DISCORD_QR_WEBHOOK_URL", properties["DISCORD_QR_WEBHOOK_URL"].toString())
+    }
+
     buildTypes {
         debug {
             buildConfigField("String", "BASE_URL", properties["DEV_BASE_URL"].toString())

--- a/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
@@ -6,6 +6,7 @@ import com.neki.android.core.data.remote.model.request.RefreshTokenRequest
 import com.neki.android.core.data.remote.model.response.AuthResponse
 import com.neki.android.core.data.remote.model.response.BasicResponse
 import com.neki.android.core.data.remote.qualifier.UploadHttpClient
+import com.neki.android.core.data.remote.qualifier.WebhookHttpClient
 import com.neki.android.core.dataapi.auth.AuthEventManager
 import com.neki.android.core.dataapi.repository.TokenRepository
 import dagger.Module
@@ -141,6 +142,23 @@ internal object NetworkModule {
             }
 
             expectSuccess = true
+        }
+    }
+
+    @WebhookHttpClient
+    @Provides
+    @Singleton
+    fun provideWebhookHttpClient(): HttpClient {
+        return HttpClient(Android) {
+            install(DefaultRequest) {
+                url(BuildConfig.DISCORD_QR_WEBHOOK_URL)
+                header(HttpHeaders.ContentType, ContentType.Application.Json)
+            }
+
+            install(HttpTimeout) {
+                connectTimeoutMillis = TIME_OUT
+                requestTimeoutMillis = TIME_OUT
+            }
         }
     }
 

--- a/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/di/NetworkModule.kt
@@ -155,6 +155,16 @@ internal object NetworkModule {
                 header(HttpHeaders.ContentType, ContentType.Application.Json)
             }
 
+            install(Logging) {
+                logger = object : Logger {
+                    override fun log(message: String) {
+                        Timber.tag(TAG_REST_API).d(message)
+                    }
+                }
+
+                level = LogLevel.BODY
+            }
+
             install(HttpTimeout) {
                 connectTimeoutMillis = TIME_OUT
                 requestTimeoutMillis = TIME_OUT

--- a/core/data/src/main/java/com/neki/android/core/data/remote/qualifier/WebhookHttpClient.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/qualifier/WebhookHttpClient.kt
@@ -1,0 +1,8 @@
+package com.neki.android.core.data.remote.qualifier
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FUNCTION)
+annotation class WebhookHttpClient

--- a/core/data/src/main/java/com/neki/android/core/data/repository/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/di/RepositoryModule.kt
@@ -2,6 +2,7 @@ package com.neki.android.core.data.repository.di
 
 import com.neki.android.core.data.auth.AuthEventManagerImpl
 import com.neki.android.core.data.repository.impl.AuthRepositoryImpl
+import com.neki.android.core.data.repository.impl.DiscordWebhookRepositoryImpl
 import com.neki.android.core.data.repository.impl.MediaUploadRepositoryImpl
 import com.neki.android.core.data.repository.impl.FolderRepositoryImpl
 import com.neki.android.core.data.repository.impl.MapRepositoryImpl
@@ -11,6 +12,7 @@ import com.neki.android.core.data.repository.impl.TermRepositoryImpl
 import com.neki.android.core.data.repository.impl.TokenRepositoryImpl
 import com.neki.android.core.data.repository.impl.UserRepositoryImpl
 import com.neki.android.core.dataapi.auth.AuthEventManager
+import com.neki.android.core.dataapi.repository.DiscordWebhookRepository
 import com.neki.android.core.dataapi.repository.FolderRepository
 import com.neki.android.core.dataapi.repository.AuthRepository
 import com.neki.android.core.dataapi.repository.MediaUploadRepository
@@ -89,4 +91,10 @@ internal interface RepositoryModule {
     fun bindTermRepositoryImpl(
         termRepositoryImpl: TermRepositoryImpl,
     ): TermRepository
+
+    @Binds
+    @Singleton
+    fun bindDiscordWebhookRepositoryImpl(
+        discordWebhookRepositoryImpl: DiscordWebhookRepositoryImpl,
+    ): DiscordWebhookRepository
 }

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/DiscordWebhookRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/DiscordWebhookRepositoryImpl.kt
@@ -1,0 +1,38 @@
+package com.neki.android.core.data.repository.impl
+
+import com.neki.android.core.data.remote.qualifier.WebhookHttpClient
+import com.neki.android.core.dataapi.repository.DiscordWebhookRepository
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import timber.log.Timber
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+class DiscordWebhookRepositoryImpl @Inject constructor(
+    @WebhookHttpClient private val client: HttpClient,
+) : DiscordWebhookRepository {
+
+    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+    override suspend fun logUnsupportedBrandQR(scannedUrl: String) {
+        val message = "**[미지원 브랜드 QR]**\\nURL: $scannedUrl\\n시간: ${LocalDateTime.now().format(formatter)}"
+        send(message)
+    }
+
+    override suspend fun logWebViewExitWithoutImage(scannedUrl: String) {
+        val message = "**[이미지 미감지 이탈]**\\nURL: $scannedUrl\\n시간: ${LocalDateTime.now().format(formatter)}"
+        send(message)
+    }
+
+    private suspend fun send(content: String) {
+        runCatching {
+            client.post("") {
+                setBody("""{"content":"$content"}""")
+            }
+        }.onFailure { e ->
+            Timber.e(e, "Discord webhook 전송 실패")
+        }
+    }
+}

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/DiscordWebhookRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/DiscordWebhookRepositoryImpl.kt
@@ -6,7 +6,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import timber.log.Timber
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
@@ -14,22 +14,41 @@ class DiscordWebhookRepositoryImpl @Inject constructor(
     @WebhookHttpClient private val client: HttpClient,
 ) : DiscordWebhookRepository {
 
-    private val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
-
     override suspend fun logUnsupportedBrandQR(scannedUrl: String) {
-        val message = "**[미지원 브랜드 QR]**\\nURL: $scannedUrl\\n시간: ${LocalDateTime.now().format(formatter)}"
-        send(message)
+        sendEmbed(
+            description = "지원하지 않는 브랜드의 QR 코드가 스캔되었습니다.",
+            color = 15548997,
+            scannedUrl = scannedUrl,
+        )
     }
 
     override suspend fun logWebViewExitWithoutImage(scannedUrl: String) {
-        val message = "**[이미지 미감지 이탈]**\\nURL: $scannedUrl\\n시간: ${LocalDateTime.now().format(formatter)}"
-        send(message)
+        sendEmbed(
+            description = "지원 브랜드 QR로 WebView에 진입했으나, 이미지 URL을 감지하지 못한 채 이탈했습니다.",
+            color = 16776960,
+            scannedUrl = scannedUrl,
+        )
     }
 
-    private suspend fun send(content: String) {
+    private suspend fun sendEmbed(description: String, color: Int, scannedUrl: String) {
+        val timestamp = ZonedDateTime.now().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        val payload = """
+            {
+                "embeds": [{
+                    "title": "\uD83D\uDEA8 미지원 QR 코드 스캔 감지  [Android]",
+                    "description": "$description",
+                    "color": $color,
+                    "fields": [
+                        {"name": "URL", "value": "$scannedUrl", "inline": false}
+                    ],
+                    "timestamp": "$timestamp"
+                }]
+            }
+        """.trimIndent()
+
         runCatching {
             client.post("") {
-                setBody("""{"content":"$content"}""")
+                setBody(payload)
             }
         }.onFailure { e ->
             Timber.e(e, "Discord webhook 전송 실패")

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
@@ -1,14 +1,28 @@
 package com.neki.android.feature.photo_upload.impl.qrscan
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.neki.android.core.dataapi.repository.DiscordWebhookRepository
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
 import com.neki.android.feature.photo_upload.impl.BuildConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-internal class QRScanViewModel @Inject constructor() : ViewModel() {
+internal class QRScanViewModel @Inject constructor(
+    private val discordWebhookRepository: DiscordWebhookRepository,
+) : ViewModel() {
+
+    private val logScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    private var webViewEnteredUrl: String? = null
+    private var imageDetected: Boolean = false
+    private var isDownloadRequiredBrand: Boolean = false
 
     val store: MviIntentStore<QRScanState, QRScanIntent, QRScanSideEffect> =
         mviIntentStore(
@@ -68,6 +82,7 @@ internal class QRScanViewModel @Inject constructor() : ViewModel() {
 
                 if (isSupportedBrand(scannedUrl)) {
                     if (isShouldFirstDownloadBrand(scannedUrl)) {
+                        isDownloadRequiredBrand = true
                         reduce {
                             copy(
                                 scannedUrl = intent.scannedUrl,
@@ -75,6 +90,7 @@ internal class QRScanViewModel @Inject constructor() : ViewModel() {
                             )
                         }
                     } else {
+                        webViewEnteredUrl = scannedUrl
                         reduce {
                             copy(
                                 scannedUrl = intent.scannedUrl,
@@ -83,6 +99,9 @@ internal class QRScanViewModel @Inject constructor() : ViewModel() {
                         }
                     }
                 } else {
+                    viewModelScope.launch {
+                        discordWebhookRepository.logUnsupportedBrandQR(scannedUrl)
+                    }
                     reduce { copy(isUnSupportedBrandDialogShown = true) }
                 }
             }
@@ -92,7 +111,10 @@ internal class QRScanViewModel @Inject constructor() : ViewModel() {
                 postSideEffect(QRScanSideEffect.ShowToast("QR코드를 인식하지 못했습니다."))
             }
 
-            is QRScanIntent.DetectImageUrl -> postSideEffect(QRScanSideEffect.SetQRScannedResult(intent.imageUrl))
+            is QRScanIntent.DetectImageUrl -> {
+                imageDetected = true
+                postSideEffect(QRScanSideEffect.SetQRScannedResult(intent.imageUrl))
+            }
 
             QRScanIntent.DismissShouldDownloadDialog -> reduce { copy(isDownloadNeededDialogShown = false) }
             QRScanIntent.ClickGoDownload -> reduce {
@@ -105,6 +127,16 @@ internal class QRScanViewModel @Inject constructor() : ViewModel() {
             QRScanIntent.DismissUnSupportedBrandDialog -> reduce { copy(isUnSupportedBrandDialogShown = false) }
             QRScanIntent.ClickUploadGallery -> postSideEffect(QRScanSideEffect.SetOpenGalleryResult)
             QRScanIntent.ClickProposeBrand -> postSideEffect(QRScanSideEffect.OpenBrandProposalUrl)
+        }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        val url = webViewEnteredUrl
+        if (url != null && !imageDetected && !isDownloadRequiredBrand) {
+            logScope.launch {
+                discordWebhookRepository.logWebViewExitWithoutImage(url)
+            }
         }
     }
 

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
@@ -2,23 +2,21 @@ package com.neki.android.feature.photo_upload.impl.qrscan
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.neki.android.core.common.coroutine.di.ApplicationScope
 import com.neki.android.core.dataapi.repository.DiscordWebhookRepository
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
 import com.neki.android.feature.photo_upload.impl.BuildConfig
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 internal class QRScanViewModel @Inject constructor(
     private val discordWebhookRepository: DiscordWebhookRepository,
+    @ApplicationScope private val applicationScope: CoroutineScope,
 ) : ViewModel() {
-
-    private val logScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     private var webViewEnteredUrl: String? = null
     private var imageDetected: Boolean = false
@@ -134,7 +132,7 @@ internal class QRScanViewModel @Inject constructor(
         super.onCleared()
         val url = webViewEnteredUrl
         if (url != null && !imageDetected && !isDownloadRequiredBrand) {
-            logScope.launch {
+            applicationScope.launch {
                 discordWebhookRepository.logWebViewExitWithoutImage(url)
             }
         }

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/component/QRScannerContent.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/component/QRScannerContent.kt
@@ -210,6 +210,11 @@ internal fun QRScannerContent(
             buttonText = "사진 다운로드하러가기",
             onDismissRequest = { onIntent(QRScanIntent.DismissShouldDownloadDialog) },
             onClick = { onIntent(QRScanIntent.ClickGoDownload) },
+            properties = DialogProperties(
+                usePlatformDefaultWidth = false,
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true,
+            ),
         )
     }
 
@@ -222,6 +227,11 @@ internal fun QRScannerContent(
             onDismissRequest = { onIntent(QRScanIntent.DismissUnSupportedBrandDialog) },
             onButtonClick = { onIntent(QRScanIntent.ClickUploadGallery) },
             onTextButtonClick = { onIntent(QRScanIntent.ClickProposeBrand) },
+            properties = DialogProperties(
+                usePlatformDefaultWidth = false,
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true,
+            ),
         )
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #170

## 📙 작업 설명
- `DiscordWebhookRepository` 인터페이스 및 구현체 생성 (Ktor HttpClient 활용)
- `@WebhookHttpClient` qualifier 추가 및 Discord Webhook 전용 HttpClient 제공
- `DISCORD_QR_WEBHOOK_URL` BuildConfig 설정 (core/data)
- QRScanViewModel에 QR 스캔 실패 케이스 로깅 로직 추가
  - Case 1: 미지원 브랜드 QR 스캔 시 해당 URL Discord 전송
  - Case 2: 지원 브랜드 WebView 진입 후 이미지 미감지 이탈 시 Discord 전송 (다운로드 필요 브랜드 제외)

## 🧪 테스트 내역 (선택)
- [x] QR 스캔 진입 시 테스트 메시지 Discord 채널 수신 확인

## 📸 스크린샷 또는 시연 영상 (선택)

## 💬 추가 설명 or 리뷰 포인트 (선택)
- `onCleared()` 시점에 Case 2 로깅을 위해 `viewModelScope`와 별도의 `logScope`를 사용합니다
- `local.properties`에 `DISCORD_QR_WEBHOOK_URL` 추가 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * QR 스캔 관련 이벤트(지원되지 않는 브랜드 QR, 웹뷰 종료 시 이미지 미감지)를 외부로 전송해 기록합니다.

* **개선사항**
  * QR 스캔 화면의 대화상자 동작이 개선되어 뒤로가기 및 외부 클릭으로 닫을 수 있습니다.
  * 관련 로깅 경로 추가로 문제 추적 및 모니터링이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->