### PR TITLE
[feat] #173 외부 앱에서 이미지 공유 수신 기능 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,16 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
         </activity>
 
         <activity

--- a/app/src/main/java/com/neki/android/app/MainActivity.kt
+++ b/app/src/main/java/com/neki/android/app/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.neki.android.app
 
+import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.widget.Toast
@@ -8,7 +9,10 @@ import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation3.runtime.entryProvider
 import com.neki.android.app.main.MainRoute
@@ -29,9 +33,29 @@ import com.neki.android.feature.auth.api.AuthNavKey
 import com.neki.android.feature.auth.impl.navigation.authEntryProvider
 import com.neki.android.feature.photo_upload.api.navigateToQRScan
 import com.neki.android.feature.photo_upload.api.navigateToUploadAlbum
+import android.net.Uri
+import androidx.core.content.IntentCompat
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+
+private fun Intent.extractShareUriStrings(): ImmutableList<String> {
+    val uris: List<Uri> = when (action) {
+        Intent.ACTION_SEND -> {
+            IntentCompat.getParcelableExtra(this, Intent.EXTRA_STREAM, Uri::class.java)
+                ?.let { listOf(it) } ?: emptyList()
+        }
+        Intent.ACTION_SEND_MULTIPLE -> {
+            IntentCompat.getParcelableArrayListExtra(this, Intent.EXTRA_STREAM, Uri::class.java)
+                ?: emptyList()
+        }
+        else -> emptyList()
+    }
+    return uris.map { it.toString() }.toImmutableList()
+}
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -54,8 +78,12 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var authEventManager: AuthEventManager
 
+    private var pendingShareUriStrings by mutableStateOf<ImmutableList<String>>(persistentListOf())
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        pendingShareUriStrings = intent.extractShareUriStrings()
 
         enableEdgeToEdge(
             navigationBarStyle = SystemBarStyle.auto(
@@ -97,6 +125,8 @@ class MainActivity : ComponentActivity() {
                                     navigateToQRScan = mainNavigator::navigateToQRScan,
                                     navigateToUploadAlbumWithGallery = mainNavigator::navigateToUploadAlbum,
                                     navigateToUploadAlbumWithQRScan = mainNavigator::navigateToUploadAlbum,
+                                    pendingShareUriStrings = pendingShareUriStrings,
+                                    onShareUrisConsumed = { pendingShareUriStrings = persistentListOf() },
                                 )
                             }
                         }
@@ -105,6 +135,14 @@ class MainActivity : ComponentActivity() {
             }
         }
         observeAuthEvents()
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        val uriStrings = intent.extractShareUriStrings()
+        if (uriStrings.isNotEmpty()) {
+            pendingShareUriStrings = uriStrings
+        }
     }
 
     private fun observeAuthEvents() {

--- a/app/src/main/java/com/neki/android/app/main/MainContract.kt
+++ b/app/src/main/java/com/neki/android/app/main/MainContract.kt
@@ -18,6 +18,7 @@ sealed interface MainIntent {
     data object ClickQRScan : MainIntent
     data object ClickGalleryUpload : MainIntent
     data class SelectGalleryImage(val uris: List<Uri>) : MainIntent
+    data class ShareImageReceived(val uris: List<Uri>) : MainIntent
     data class QRCodeScanned(val imageUrl: String) : MainIntent
     data object DismissSelectWithAlbumDialog : MainIntent
     data object ClickUploadWithAlbum : MainIntent

--- a/app/src/main/java/com/neki/android/app/main/MainScreen.kt
+++ b/app/src/main/java/com/neki/android/app/main/MainScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -32,6 +33,9 @@ import com.neki.android.core.navigation.result.ResultEffect
 import com.neki.android.core.ui.component.LoadingDialog
 import com.neki.android.core.ui.compose.collectWithLifecycle
 import com.neki.android.core.ui.toast.NekiToast
+import androidx.core.net.toUri
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import com.neki.android.feature.archive.api.ArchiveNavKey
 import com.neki.android.feature.archive.api.ArchiveResult
 import com.neki.android.feature.map.api.MapNavKey
@@ -52,6 +56,8 @@ fun MainRoute(
     navigateToQRScan: () -> Unit,
     navigateToUploadAlbumWithGallery: (List<String>) -> Unit,
     navigateToUploadAlbumWithQRScan: (String) -> Unit,
+    pendingShareUriStrings: ImmutableList<String> = persistentListOf(),
+    onShareUrisConsumed: () -> Unit = {},
     viewModel: MainViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.store.uiState.collectAsStateWithLifecycle()
@@ -66,6 +72,13 @@ fun MainRoute(
             viewModel.store.onIntent(MainIntent.SelectGalleryImage(uris))
         } else {
             Timber.d("No media selected")
+        }
+    }
+
+    LaunchedEffect(pendingShareUriStrings) {
+        if (pendingShareUriStrings.isNotEmpty()) {
+            viewModel.store.onIntent(MainIntent.ShareImageReceived(pendingShareUriStrings.map { it.toUri() }))
+            onShareUrisConsumed()
         }
     }
 

--- a/app/src/main/java/com/neki/android/app/main/MainScreen.kt
+++ b/app/src/main/java/com/neki/android/app/main/MainScreen.kt
@@ -166,7 +166,7 @@ fun MainScreen(
         )
     }
 
-    if (uiState.isLoading) {
+    if (uiState.isLoading && !uiState.isShowSelectWithAlbumDialog) {
         LoadingDialog()
     }
 

--- a/app/src/main/java/com/neki/android/app/main/MainViewModel.kt
+++ b/app/src/main/java/com/neki/android/app/main/MainViewModel.kt
@@ -44,6 +44,7 @@ class MainViewModel @Inject constructor(
                 postSideEffect(MainSideEffect.OpenGallery)
             }
             is MainIntent.SelectGalleryImage -> reduce { copy(isShowSelectWithAlbumDialog = true, selectedUris = intent.uris.toImmutableList()) }
+            is MainIntent.ShareImageReceived -> reduce { copy(isShowSelectWithAlbumDialog = true, selectedUris = intent.uris.toImmutableList()) }
             is MainIntent.QRCodeScanned -> reduce { copy(scannedImageUrl = intent.imageUrl, isShowSelectWithAlbumDialog = true) }
             MainIntent.DismissSelectWithAlbumDialog -> reduce {
                 copy(


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #173

## 📙 작업 설명
- AndroidManifest에 `ACTION_SEND` / `ACTION_SEND_MULTIPLE` intent-filter 등록 (`image/*`)
- MainActivity에서 공유 Intent URI 추출 및 pending 관리 (`onCreate`, `onNewIntent`)
- MainRoute로 `ImmutableList<String>` 전달 후 ViewModel에서 `Uri` 변환하여 기존 업로드 플로우 재사용
- 공유 수신 시 `LoadingDialog`와 `SelectWithAlbumDialog` 겹침 방지

## 🧪 테스트 내역 (선택)
- [x] 갤러리에서 단일 사진 공유 → 앨범 선택 다이얼로그 → 업로드 정상 동작
- [x] 갤러리에서 다중 사진 공유 → 앨범 선택 다이얼로그 → 업로드 정상 동작
- [x] 비로그인 상태에서 공유 → 로그인 후 업로드 플로우 정상 진입
- [x] 앱 실행 중 공유 → 정상 동작 (onNewIntent)

## 📸 스크린샷 또는 시연 영상 (선택)

| 단일 이미지 공유 | 다중 이미지 공유 |
|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/b6fc69a9-1240-420e-8ea8-b6c9ec504d41" width="250" controls></video> | <video src="https://github.com/user-attachments/assets/b36050f8-5d4f-4c15-a4d3-9db5635ab40b" width="250" controls></video> |

| 비로그인 상태에서 공유 |
|:---:|
| <video src="https://github.com/user-attachments/assets/7425d65d-5ee4-45ed-b381-3a13ee2d976f" width="250" controls></video> |

## 💬 추가 설명 or 리뷰 포인트 (선택)
- 앱이 사용 중일 때에도 `onNewIntent`를 통해 공유 수신이 정상 작동합니다.