### PR TITLE
[feat] #175 사진/포즈 상세 화면 핀치 줌 기능 추가

### DIFF
--- a/feature/archive/impl/build.gradle.kts
+++ b/feature/archive/impl/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.paging.compose)
+    implementation(libs.zoomable)
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
@@ -8,7 +8,7 @@ data class PhotoDetailState(
     val currentPage: Int = 0,
     val isShowDeleteDialog: Boolean = false,
 ) {
-    val currentIndex get() = if (photos.isEmpty()) 0 else currentPage % photos.size
+    val currentIndex get() = if (photos.isEmpty()) 0 else currentPage.coerceIn(0, photos.lastIndex)
     val photo: Photo get() = photos.getOrElse(currentIndex) { Photo() }
 }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -2,7 +2,6 @@ package com.neki.android.feature.archive.impl.photo_detail
 
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -52,7 +51,9 @@ internal fun PhotoDetailRoute(
     val context = LocalContext.current
     val nekiToast = remember { NekiToast(context) }
     val resultEventBus = LocalResultEventBus.current
-    val pagerState = rememberPagerState(initialPage = uiState.currentPage) { Int.MAX_VALUE }
+    val pagerState = rememberPagerState(initialPage = uiState.currentPage) {
+        uiState.photos.size.coerceAtLeast(1)
+    }
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(pagerState) {
@@ -97,7 +98,7 @@ internal fun PhotoDetailRoute(
 internal fun PhotoDetailScreen(
     uiState: PhotoDetailState = PhotoDetailState(),
     onIntent: (PhotoDetailIntent) -> Unit = {},
-    pagerState: PagerState = rememberPagerState { Int.MAX_VALUE },
+    pagerState: PagerState = rememberPagerState { uiState.photos.size.coerceAtLeast(1) },
 ) {
     Column(
         modifier = Modifier
@@ -117,33 +118,31 @@ internal fun PhotoDetailScreen(
             state = pagerState,
             beyondViewportPageCount = 1,
         ) { page ->
-            val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
+            val index = if (uiState.photos.isEmpty()) 0 else page.coerceIn(0, uiState.photos.lastIndex)
             val zoomState = rememberZoomState()
             var contentWidth by remember { mutableIntStateOf(0) }
-            Box {
-                AsyncImage(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .onSizeChanged { contentWidth = it.width }
-                        .zoomable(
-                            zoomState = zoomState,
-                            scrollGesturePropagation = ScrollGesturePropagation.ContentEdge,
-                            onTap = { position: Offset ->
-                                if (!pagerState.isScrollInProgress && contentWidth > 0 && zoomState.scale <= 1f) {
-                                    if (position.x < contentWidth / 2) {
-                                        onIntent(PhotoDetailIntent.ClickLeftPhoto)
-                                    } else {
-                                        onIntent(PhotoDetailIntent.ClickRightPhoto)
-                                    }
+            AsyncImage(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .onSizeChanged { contentWidth = it.width }
+                    .zoomable(
+                        zoomState = zoomState,
+                        scrollGesturePropagation = ScrollGesturePropagation.ContentEdge,
+                        onTap = { position: Offset ->
+                            if (!pagerState.isScrollInProgress && contentWidth > 0 && zoomState.scale <= 1f) {
+                                if (position.x < contentWidth / 2) {
+                                    onIntent(PhotoDetailIntent.ClickLeftPhoto)
+                                } else {
+                                    onIntent(PhotoDetailIntent.ClickRightPhoto)
                                 }
-                            },
-                        ),
-                    model = uiState.photos.getOrNull(index)?.imageUrl,
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
-                    onSuccess = { state -> zoomState.setContentSize(state.painter.intrinsicSize) },
-                )
-            }
+                            }
+                        },
+                    ),
+                model = uiState.photos.getOrNull(index)?.imageUrl,
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                onSuccess = { state -> zoomState.setContentSize(state.painter.intrinsicSize) },
+            )
         }
 
         PhotoDetailActionBar(

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -18,10 +18,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import net.engawapg.lib.zoomable.ScrollGesturePropagation
+import net.engawapg.lib.zoomable.rememberZoomState
+import net.engawapg.lib.zoomable.zoomable
 import com.neki.android.core.designsystem.DevicePreview
 import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
 import com.neki.android.core.designsystem.topbar.BackTitleTopBar
@@ -107,39 +111,49 @@ internal fun PhotoDetailScreen(
         HorizontalPager(
             modifier = Modifier
                 .fillMaxWidth()
-                .weight(1f),
+                .weight(1f)
+                .clipToBounds(),
             state = pagerState,
             beyondViewportPageCount = 1,
         ) { page ->
             val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
+            val zoomState = rememberZoomState()
             Box {
                 AsyncImage(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .zoomable(
+                            zoomState = zoomState,
+                            scrollGesturePropagation = ScrollGesturePropagation.NotZoomed,
+                        ),
                     model = uiState.photos.getOrNull(index)?.imageUrl,
                     contentDescription = null,
                     contentScale = ContentScale.Fit,
+                    onSuccess = { state -> zoomState.setContentSize(state.painter.intrinsicSize) },
                 )
-                Row(modifier = Modifier.matchParentSize()) {
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
-                            .noRippleClickableSingle {
-                                if (!pagerState.isScrollInProgress) {
-                                    onIntent(PhotoDetailIntent.ClickLeftPhoto)
-                                }
-                            },
-                    )
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
-                            .noRippleClickableSingle {
-                                if (!pagerState.isScrollInProgress) {
-                                    onIntent(PhotoDetailIntent.ClickRightPhoto)
-                                }
-                            },
-                    )
+                if (zoomState.scale <= 1f) {
+                    Row(modifier = Modifier.matchParentSize()) {
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxHeight()
+                                .noRippleClickableSingle {
+                                    if (!pagerState.isScrollInProgress) {
+                                        onIntent(PhotoDetailIntent.ClickLeftPhoto)
+                                    }
+                                },
+                        )
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .fillMaxHeight()
+                                .noRippleClickableSingle {
+                                    if (!pagerState.isScrollInProgress) {
+                                        onIntent(PhotoDetailIntent.ClickRightPhoto)
+                                    }
+                                },
+                        )
+                    }
                 }
             }
         }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -120,7 +120,7 @@ internal fun PhotoDetailScreen(
             val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
             val zoomState = rememberZoomState()
             var contentWidth by remember { mutableIntStateOf(0) }
-            Box(modifier = Modifier.clipToBounds()) {
+            Box {
                 AsyncImage(
                     modifier = Modifier
                         .fillMaxSize()

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -4,8 +4,6 @@ import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.pager.HorizontalPager
@@ -14,32 +12,35 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
-import net.engawapg.lib.zoomable.ScrollGesturePropagation
-import net.engawapg.lib.zoomable.rememberZoomState
-import net.engawapg.lib.zoomable.zoomable
 import com.neki.android.core.designsystem.DevicePreview
-import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
 import com.neki.android.core.designsystem.topbar.BackTitleTopBar
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.model.Photo
 import com.neki.android.core.navigation.result.LocalResultEventBus
-import com.neki.android.feature.archive.api.PhotoDetailResult
 import com.neki.android.core.ui.component.LoadingDialog
 import com.neki.android.core.ui.compose.collectWithLifecycle
 import com.neki.android.core.ui.toast.NekiToast
+import com.neki.android.feature.archive.api.PhotoDetailResult
 import com.neki.android.feature.archive.impl.component.DeletePhotoDialog
 import com.neki.android.feature.archive.impl.photo_detail.component.PhotoDetailActionBar
 import com.neki.android.feature.archive.impl.util.ImageDownloader
 import kotlinx.coroutines.launch
+import net.engawapg.lib.zoomable.ScrollGesturePropagation
+import net.engawapg.lib.zoomable.rememberZoomState
+import net.engawapg.lib.zoomable.zoomable
 import timber.log.Timber
 
 @Composable
@@ -118,43 +119,30 @@ internal fun PhotoDetailScreen(
         ) { page ->
             val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
             val zoomState = rememberZoomState()
-            Box {
+            var contentWidth by remember { mutableIntStateOf(0) }
+            Box(modifier = Modifier.clipToBounds()) {
                 AsyncImage(
                     modifier = Modifier
                         .fillMaxSize()
+                        .onSizeChanged { contentWidth = it.width }
                         .zoomable(
                             zoomState = zoomState,
-                            scrollGesturePropagation = ScrollGesturePropagation.NotZoomed,
+                            scrollGesturePropagation = ScrollGesturePropagation.ContentEdge,
+                            onTap = { position: Offset ->
+                                if (!pagerState.isScrollInProgress && contentWidth > 0 && zoomState.scale <= 1f) {
+                                    if (position.x < contentWidth / 2) {
+                                        onIntent(PhotoDetailIntent.ClickLeftPhoto)
+                                    } else {
+                                        onIntent(PhotoDetailIntent.ClickRightPhoto)
+                                    }
+                                }
+                            },
                         ),
                     model = uiState.photos.getOrNull(index)?.imageUrl,
                     contentDescription = null,
                     contentScale = ContentScale.Fit,
                     onSuccess = { state -> zoomState.setContentSize(state.painter.intrinsicSize) },
                 )
-                if (zoomState.scale <= 1f) {
-                    Row(modifier = Modifier.matchParentSize()) {
-                        Box(
-                            modifier = Modifier
-                                .weight(1f)
-                                .fillMaxHeight()
-                                .noRippleClickableSingle {
-                                    if (!pagerState.isScrollInProgress) {
-                                        onIntent(PhotoDetailIntent.ClickLeftPhoto)
-                                    }
-                                },
-                        )
-                        Box(
-                            modifier = Modifier
-                                .weight(1f)
-                                .fillMaxHeight()
-                                .noRippleClickableSingle {
-                                    if (!pagerState.isScrollInProgress) {
-                                        onIntent(PhotoDetailIntent.ClickRightPhoto)
-                                    }
-                                },
-                        )
-                    }
-                }
             }
         }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
@@ -83,7 +83,11 @@ class PhotoDetailViewModel @AssistedInject constructor(
                 }
             }
 
-            PhotoDetailIntent.ClickRightPhoto -> postSideEffect(PhotoDetailSideEffect.AnimateToPage(state.currentPage + 1))
+            PhotoDetailIntent.ClickRightPhoto -> {
+                if (state.currentPage < state.photos.lastIndex) {
+                    postSideEffect(PhotoDetailSideEffect.AnimateToPage(state.currentPage + 1))
+                }
+            }
 
             is PhotoDetailIntent.PageChanged -> {
                 reduce { copy(currentPage = intent.page) }

--- a/feature/pose/impl/build.gradle.kts
+++ b/feature/pose/impl/build.gradle.kts
@@ -11,4 +11,5 @@ dependencies {
 
     implementation(libs.kotlinx.collections.immutable)
     implementation(libs.androidx.paging.compose)
+    implementation(libs.zoomable)
 }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailScreen.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailScreen.kt
@@ -3,7 +3,6 @@ package com.neki.android.feature.pose.impl.detail
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailScreen.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.neki.android.feature.pose.impl.detail
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -8,10 +9,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import net.engawapg.lib.zoomable.rememberZoomState
+import net.engawapg.lib.zoomable.zoomable
 import com.neki.android.core.designsystem.DevicePreview
 import com.neki.android.core.designsystem.topbar.BackTitleTopBar
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
@@ -66,15 +70,23 @@ internal fun PoseDetailScreen(
             title = "포즈 상세",
             onBack = { onIntent(PoseDetailIntent.ClickBackIcon) },
         )
-        AsyncImage(
-            model = uiState.pose.poseImageUrl,
-            contentDescription = null,
+        Box(
             modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-            contentScale = ContentScale.Fit,
-            alignment = Alignment.Center,
-        )
+                .weight(1f)
+                .clipToBounds(),
+        ) {
+            val zoomState = rememberZoomState()
+            AsyncImage(
+                model = uiState.pose.poseImageUrl,
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .zoomable(zoomState),
+                contentScale = ContentScale.Fit,
+                alignment = Alignment.Center,
+                onSuccess = { state -> zoomState.setContentSize(state.painter.intrinsicSize) },
+            )
+        }
         PoseActionBar(
             isBookmarked = uiState.pose.isBookmarked,
             onClickBookmark = { onIntent(PoseDetailIntent.ClickBookmarkIcon) },

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ detekt = "1.23.8"
 barcodeScanning = "17.3.0"
 kakao = "2.23.1"
 coil = "3.3.0"
+zoomable = "2.11.1"
 haze = "1.7.1"
 lottie = "6.7.1"
 exifinterface = "1.4.2"
@@ -107,6 +108,8 @@ kakao-user = { module = "com.kakao.sdk:v2-user", version.ref = "kakao" }
 
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+
+zoomable = { group = "net.engawapg.lib", name = "zoomable", version.ref = "zoomable" }
 
 haze = { group = "dev.chrisbanes.haze", name = "haze", version.ref = "haze" }
 haze-materials = { group = "dev.chrisbanes.haze", name = "haze-materials", version.ref = "haze" }


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #175

## 📙 작업 설명
- `net.engawapg.lib:zoomable 2.11.1` 라이브러리 추가
- 사진 상세 화면(`PhotoDetailScreen`) 핀치 줌 적용
  - `HorizontalPager` 내 `AsyncImage`에 `Modifier.zoomable` 적용
  - `onTap`으로 좌/우 탭 페이지 이동 처리 (줌인 상태에서는 비활성)
  - `ScrollGesturePropagation.ContentEdge`로 줌인 상태에서 끝까지 드래그 후 스와이프 전파
  - `clipToBounds()`로 확대 이미지가 TopBar/ActionBar 영역 침범 방지
- 포즈 상세 화면(`PoseDetailScreen`) 핀치 줌 적용
  - `Box` + `clipToBounds()`로 확대 영역 제한
  - `AsyncImage`에 `Modifier.zoomable` 적용
- `PhotoDetailPager` 무한 스크롤 제거 및 인덱스 처리 로직 수정
  - `HorizontalPager`의 `pageCount`를 `Int.MAX_VALUE`에서 실제 사진 리스트 크기로 변경
  - `currentIndex` 계산 방식을 나머지 연산에서 `coerceIn`을 통한 범위 제한으로 변경
  - 다음 사진 이동 시 마지막 인덱스 초과 방지 조건 추가
  - 불필요한 `Box` 레이아웃 제거 및 코드 정리

## 🧪 테스트 내역 (선택)
- [ ] 사진 상세 핀치 줌 동작 확인
- [ ] 포즈 상세 핀치 줌 동작 확인
- [ ] 줌인 상태에서 드래그 후 스와이프 페이지 전환 확인
- [ ] 줌 안 된 상태에서 좌/우 탭 페이지 이동 확인
- [ ] 확대 시 TopBar/ActionBar 침범 없음 확인

## 📸 스크린샷 또는 시연 영상 (선택)

| 사진 상세 | 포즈 상세 |
|-----------|-----------|
|           |           |

## 💬 추가 설명 or 리뷰 포인트 (선택)
- 이 브랜치에 #161 ArchiveResult 화면별 Result 타입 분리 커밋이 함께 포함되어 있습니다