### PR TITLE
[feat] #168 사진 상세 메모 기능 추가

### DIFF
--- a/app/src/main/java/com/neki/android/app/navigation/keys/Keys.kt
+++ b/app/src/main/java/com/neki/android/app/navigation/keys/Keys.kt
@@ -7,7 +7,5 @@ import com.neki.android.feature.auth.api.AuthNavKey
 
 internal val START_AUTH_NAV_KEY = AuthNavKey.Splash
 internal val START_MAIN_NAV_KEY = ArchiveNavKey.Archive
-
-// TODO: 테스트용 - 반드시 원복할 것
-internal val START_ROOT_NAV_KEY = RootNavKey.Main
+internal val START_ROOT_NAV_KEY = RootNavKey.Auth(START_AUTH_NAV_KEY)
 internal val TOP_LEVEL_MAIN_NAV_KEYS = TopLevelNavItem.entries.map { it.navKey }

--- a/app/src/main/java/com/neki/android/app/navigation/keys/Keys.kt
+++ b/app/src/main/java/com/neki/android/app/navigation/keys/Keys.kt
@@ -7,5 +7,7 @@ import com.neki.android.feature.auth.api.AuthNavKey
 
 internal val START_AUTH_NAV_KEY = AuthNavKey.Splash
 internal val START_MAIN_NAV_KEY = ArchiveNavKey.Archive
-internal val START_ROOT_NAV_KEY = RootNavKey.Auth(START_AUTH_NAV_KEY)
+
+// TODO: 테스트용 - 반드시 원복할 것
+internal val START_ROOT_NAV_KEY = RootNavKey.Main
 internal val TOP_LEVEL_MAIN_NAV_KEYS = TopLevelNavItem.entries.map { it.navKey }

--- a/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/PhotoRepository.kt
+++ b/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/PhotoRepository.kt
@@ -25,6 +25,8 @@ interface PhotoRepository {
 
     suspend fun updateFavorite(photoId: Long, favorite: Boolean): Result<Unit>
 
+    suspend fun updateMemo(photoId: Long, memo: String): Result<Unit>
+
     suspend fun getPhotosPage(
         folderId: Long? = null,
         page: Int = 0,

--- a/core/data/src/main/java/com/neki/android/core/data/remote/api/PhotoService.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/api/PhotoService.kt
@@ -3,6 +3,7 @@ package com.neki.android.core.data.remote.api
 import com.neki.android.core.data.remote.model.request.DeletePhotoRequest
 import com.neki.android.core.data.remote.model.request.RegisterPhotoRequest
 import com.neki.android.core.data.remote.model.request.UpdateFavoriteRequest
+import com.neki.android.core.data.remote.model.request.UpdateMemoRequest
 import com.neki.android.core.data.remote.model.response.BasicNullableResponse
 import com.neki.android.core.data.remote.model.response.BasicResponse
 import com.neki.android.core.data.remote.model.response.FavoriteSummaryResponse
@@ -15,6 +16,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.patch
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import javax.inject.Inject
 
@@ -50,6 +52,13 @@ class PhotoService @Inject constructor(
     suspend fun updateFavorite(photoId: Long, favorite: Boolean): BasicNullableResponse<Unit> {
         return client.patch("/api/photos/$photoId/favorite") {
             setBody(UpdateFavoriteRequest(favorite))
+        }.body()
+    }
+
+    // 메모 수정
+    suspend fun updateMemo(photoId: Long, memo: String): BasicNullableResponse<Unit> {
+        return client.put("/api/photos/$photoId") {
+            setBody(UpdateMemoRequest(memo))
         }.body()
     }
 

--- a/core/data/src/main/java/com/neki/android/core/data/remote/model/request/UpdateMemoRequest.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/model/request/UpdateMemoRequest.kt
@@ -1,0 +1,9 @@
+package com.neki.android.core.data.remote.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateMemoRequest(
+    @SerialName("memo") val memo: String,
+)

--- a/core/data/src/main/java/com/neki/android/core/data/remote/model/response/PhotoResponse.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/model/response/PhotoResponse.kt
@@ -20,6 +20,7 @@ data class PhotoResponse(
         @SerialName("width") val width: Int? = null,
         @SerialName("height") val height: Int? = null,
         @SerialName("createdAt") val createdAt: String,
+        @SerialName("memo") val memo: String? = null, // TODO: API에 memo 필드 추가 후 nullable 제거
     ) {
         internal fun toModel() = Photo(
             id = photoId,
@@ -29,6 +30,7 @@ data class PhotoResponse(
             height = height,
             date = createdAt.toFormattedDate(),
             contentType = ContentType.fromString(contentType),
+            memo = memo.orEmpty(),
         )
     }
 

--- a/core/data/src/main/java/com/neki/android/core/data/remote/model/response/PhotoResponse.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/model/response/PhotoResponse.kt
@@ -20,7 +20,7 @@ data class PhotoResponse(
         @SerialName("width") val width: Int? = null,
         @SerialName("height") val height: Int? = null,
         @SerialName("createdAt") val createdAt: String,
-        @SerialName("memo") val memo: String? = null, // TODO: API에 memo 필드 추가 후 nullable 제거
+        @SerialName("memo") val memo: String? = null,
     ) {
         internal fun toModel() = Photo(
             id = photoId,

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/PhotoRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/PhotoRepositoryImpl.kt
@@ -65,6 +65,10 @@ class PhotoRepositoryImpl @Inject constructor(
         photoService.updateFavorite(photoId, favorite)
     }
 
+    override suspend fun updateMemo(photoId: Long, memo: String): Result<Unit> = runSuspendCatching {
+        photoService.updateMemo(photoId, memo)
+    }
+
     override suspend fun getPhotosPage(
         folderId: Long?,
         page: Int,

--- a/core/designsystem/src/main/res/drawable/icon_memo.xml
+++ b/core/designsystem/src/main/res/drawable/icon_memo.xml
@@ -1,0 +1,23 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="28dp"
+    android:height="28dp"
+    android:viewportWidth="28"
+    android:viewportHeight="28">
+  <path
+      android:pathData="M11.698,22.845H4.45C3.649,22.845 3,22.196 3,21.396V11.849C3,11.464 3.153,11.095 3.425,10.824L9.824,4.425C10.095,4.153 10.464,4 10.849,4H20.396C21.196,4 21.845,4.649 21.845,5.45V11.248"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.93285"
+      android:fillColor="#00000000"
+      android:strokeColor="#4F525F"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M3,11.731H8.315C9.116,11.731 9.765,11.082 9.765,10.282V4"
+      android:strokeWidth="1.93285"
+      android:fillColor="#00000000"
+      android:strokeColor="#4F525F"/>
+  <path
+      android:pathData="M20.699,14.347L15.035,20.012C14.91,20.137 14.822,20.294 14.78,20.465L14.37,22.141C14.196,22.85 14.84,23.487 15.547,23.308L17.204,22.886C17.373,22.843 17.527,22.755 17.649,22.632L23.317,16.965C23.694,16.588 23.694,15.976 23.317,15.598L22.066,14.347C21.689,13.97 21.077,13.97 20.699,14.347Z"
+      android:strokeWidth="1.93285"
+      android:fillColor="#00000000"
+      android:strokeColor="#4F525F"/>
+</vector>

--- a/core/model/src/main/java/com/neki/android/core/model/Photo.kt
+++ b/core/model/src/main/java/com/neki/android/core/model/Photo.kt
@@ -13,4 +13,5 @@ data class Photo(
     val width: Int? = null,
     val height: Int? = null,
     val contentType: ContentType = ContentType.JPEG,
+    val memo: String = "",
 )

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
@@ -2,11 +2,20 @@ package com.neki.android.feature.archive.impl.photo_detail
 
 import com.neki.android.core.model.Photo
 
+enum class MemoMode {
+    Closed,
+    Preview,
+    Expanded,
+    Editing,
+}
+
 data class PhotoDetailState(
     val isLoading: Boolean = false,
     val photos: List<Photo> = emptyList(),
     val currentPage: Int = 0,
     val isShowDeleteDialog: Boolean = false,
+    val memoMode: MemoMode = MemoMode.Closed,
+    val memo: String = "",
 ) {
     val currentIndex get() = if (photos.isEmpty()) 0 else currentPage % photos.size
     val photo: Photo get() = photos.getOrElse(currentIndex) { Photo() }
@@ -26,6 +35,12 @@ sealed interface PhotoDetailIntent {
     data object ClickFavoriteIcon : PhotoDetailIntent
     data class FavoriteCommitted(val photoId: Long, val newFavorite: Boolean) : PhotoDetailIntent
     data class RevertFavorite(val photoId: Long, val originalFavorite: Boolean) : PhotoDetailIntent
+    data object ClickMemoIcon : PhotoDetailIntent
+    data object ClickMemoMore : PhotoDetailIntent
+    data object ClickMemoText : PhotoDetailIntent
+    data object ClickMemoFold : PhotoDetailIntent
+    data object ClickMemoCancel : PhotoDetailIntent
+    data class ClickMemoDone(val memo: String) : PhotoDetailIntent
     data object ClickDeleteIcon : PhotoDetailIntent
 
     // Delete Dialog Intent

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
@@ -1,6 +1,8 @@
 package com.neki.android.feature.archive.impl.photo_detail
 
 import com.neki.android.core.model.Photo
+import kotlinx.collections.immutable.ImmutableMap
+import kotlinx.collections.immutable.persistentMapOf
 
 enum class MemoMode {
     Closed,
@@ -15,7 +17,7 @@ data class PhotoDetailState(
     val currentPage: Int = 0,
     val isShowDeleteDialog: Boolean = false,
     val memo: String = "",
-    val memoModes: Map<Long, MemoMode> = emptyMap(),
+    val memoModes: ImmutableMap<Long, MemoMode> = persistentMapOf(),
 ) {
     val currentIndex get() = if (photos.isEmpty()) 0 else currentPage % photos.size
     val photo: Photo get() = photos.getOrElse(currentIndex) { Photo() }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailContract.kt
@@ -14,11 +14,13 @@ data class PhotoDetailState(
     val photos: List<Photo> = emptyList(),
     val currentPage: Int = 0,
     val isShowDeleteDialog: Boolean = false,
-    val memoMode: MemoMode = MemoMode.Closed,
     val memo: String = "",
+    val memoModes: Map<Long, MemoMode> = emptyMap(),
 ) {
     val currentIndex get() = if (photos.isEmpty()) 0 else currentPage % photos.size
     val photo: Photo get() = photos.getOrElse(currentIndex) { Photo() }
+    val currentMemoMode: MemoMode get() = memoModes[photo.id] ?: MemoMode.Closed
+    fun memoModeOf(photoId: Long): MemoMode = memoModes[photoId] ?: MemoMode.Closed
 }
 
 sealed interface PhotoDetailIntent {
@@ -39,6 +41,7 @@ sealed interface PhotoDetailIntent {
     data object ClickMemoMore : PhotoDetailIntent
     data object ClickMemoText : PhotoDetailIntent
     data object ClickMemoFold : PhotoDetailIntent
+    data class MemoTextChanged(val text: String) : PhotoDetailIntent
     data object ClickMemoCancel : PhotoDetailIntent
     data class ClickMemoDone(val memo: String) : PhotoDetailIntent
     data object ClickDeleteIcon : PhotoDetailIntent

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -1,6 +1,5 @@
 package com.neki.android.feature.archive.impl.photo_detail
 
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -12,11 +11,16 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.neki.android.core.designsystem.DevicePreview
 import com.neki.android.core.designsystem.topbar.BackTitleTopBar
@@ -92,6 +96,8 @@ internal fun PhotoDetailScreen(
 ) {
     val isMemoActive = uiState.currentMemoMode == MemoMode.Expanded ||
         uiState.currentMemoMode == MemoMode.Editing
+    val density = LocalDensity.current
+    var actionBarHeightDp by remember { mutableStateOf(0.dp) }
 
     Column(
         modifier = Modifier
@@ -121,6 +127,7 @@ internal fun PhotoDetailScreen(
                 imageUrl = photo?.imageUrl,
                 memo = pageMemo,
                 memoMode = pageMemoMode,
+                actionBarHeight = actionBarHeightDp,
                 isScrollInProgress = pagerState.isScrollInProgress,
                 isTapEnabled = pageMemoMode != MemoMode.Expanded && pageMemoMode != MemoMode.Editing,
                 onClickLeft = { onIntent(PhotoDetailIntent.ClickLeftPhoto) },
@@ -134,8 +141,11 @@ internal fun PhotoDetailScreen(
             )
         }
 
-        AnimatedVisibility(visible = uiState.currentMemoMode != MemoMode.Editing) {
+        if (uiState.currentMemoMode != MemoMode.Editing) {
             PhotoDetailActionBar(
+                modifier = Modifier.onSizeChanged { size ->
+                    actionBarHeightDp = with(density) { size.height.toDp() }
+                },
                 isFavorite = uiState.photo.isFavorite,
                 onClickDownload = { onIntent(PhotoDetailIntent.ClickDownloadIcon) },
                 onClickFavorite = { onIntent(PhotoDetailIntent.ClickFavoriteIcon) },

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -1,23 +1,34 @@
 package com.neki.android.feature.archive.impl.photo_detail
 
 import androidx.compose.animation.core.spring
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -94,60 +105,101 @@ internal fun PhotoDetailScreen(
     onIntent: (PhotoDetailIntent) -> Unit = {},
     pagerState: PagerState = rememberPagerState { Int.MAX_VALUE },
 ) {
-    Column(
+    val density = LocalDensity.current
+    var actionBarHeightPx by remember { mutableIntStateOf(0) }
+    val actionBarHeight = with(density) { actionBarHeightPx.toDp() }
+
+    Box(
         modifier = Modifier
             .fillMaxSize()
             .background(NekiTheme.colorScheme.white),
     ) {
-        BackTitleTopBar(
-            title = uiState.photo.date,
-            onBack = { onIntent(PhotoDetailIntent.ClickBackIcon) },
-        )
+        Column(modifier = Modifier.fillMaxSize()) {
+            BackTitleTopBar(
+                title = uiState.photo.date,
+                onBack = { onIntent(PhotoDetailIntent.ClickBackIcon) },
+            )
 
-        HorizontalPager(
-            modifier = Modifier
-                .fillMaxWidth()
-                .weight(1f),
-            state = pagerState,
-            beyondViewportPageCount = 1,
-        ) { page ->
-            val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
-            Box {
-                AsyncImage(
-                    modifier = Modifier.fillMaxSize(),
-                    model = uiState.photos.getOrNull(index)?.imageUrl,
-                    contentDescription = null,
-                    contentScale = ContentScale.Fit,
-                )
-                Row(modifier = Modifier.matchParentSize()) {
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
-                            .noRippleClickableSingle {
-                                if (!pagerState.isScrollInProgress) {
-                                    onIntent(PhotoDetailIntent.ClickLeftPhoto)
-                                }
-                            },
+            val isMemoActive = uiState.memoMode == MemoMode.Expanded ||
+                uiState.memoMode == MemoMode.Editing
+
+            HorizontalPager(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                state = pagerState,
+                beyondViewportPageCount = 1,
+                userScrollEnabled = !isMemoActive,
+            ) { page ->
+                val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
+                Box {
+                    AsyncImage(
+                        modifier = Modifier.fillMaxSize(),
+                        model = uiState.photos.getOrNull(index)?.imageUrl,
+                        contentDescription = null,
+                        contentScale = ContentScale.Fit,
                     )
-                    Box(
-                        modifier = Modifier
-                            .weight(1f)
-                            .fillMaxHeight()
-                            .noRippleClickableSingle {
-                                if (!pagerState.isScrollInProgress) {
-                                    onIntent(PhotoDetailIntent.ClickRightPhoto)
-                                }
-                            },
-                    )
+                    if (!isMemoActive) {
+                        Row(modifier = Modifier.matchParentSize()) {
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .fillMaxHeight()
+                                    .noRippleClickableSingle {
+                                        if (!pagerState.isScrollInProgress) {
+                                            onIntent(PhotoDetailIntent.ClickLeftPhoto)
+                                        }
+                                    },
+                            )
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .fillMaxHeight()
+                                    .noRippleClickableSingle {
+                                        if (!pagerState.isScrollInProgress) {
+                                            onIntent(PhotoDetailIntent.ClickRightPhoto)
+                                        }
+                                    },
+                            )
+                        }
+                    }
                 }
             }
+
+            Spacer(modifier = Modifier.height(actionBarHeight))
+        }
+
+        // Expanded/Editing 모드일 때 dim 오버레이
+        AnimatedVisibility(
+            visible = uiState.memoMode == MemoMode.Expanded || uiState.memoMode == MemoMode.Editing,
+            enter = fadeIn(),
+            exit = fadeOut(),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0x80202227))
+                    .noRippleClickableSingle { onIntent(PhotoDetailIntent.ClickMemoFold) },
+            )
         }
 
         PhotoDetailActionBar(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .onSizeChanged {
+                    if (uiState.memoMode == MemoMode.Closed) actionBarHeightPx = it.height
+                },
             isFavorite = uiState.photo.isFavorite,
+            memo = uiState.memo,
+            memoMode = uiState.memoMode,
             onClickDownload = { onIntent(PhotoDetailIntent.ClickDownloadIcon) },
             onClickFavorite = { onIntent(PhotoDetailIntent.ClickFavoriteIcon) },
+            onClickMemo = { onIntent(PhotoDetailIntent.ClickMemoIcon) },
+            onClickMemoMore = { onIntent(PhotoDetailIntent.ClickMemoMore) },
+            onClickMemoText = { onIntent(PhotoDetailIntent.ClickMemoText) },
+            onClickMemoFold = { onIntent(PhotoDetailIntent.ClickMemoFold) },
+            onClickMemoCancel = { onIntent(PhotoDetailIntent.ClickMemoCancel) },
+            onClickMemoDone = { onIntent(PhotoDetailIntent.ClickMemoDone(it)) },
             onClickDelete = { onIntent(PhotoDetailIntent.ClickDeleteIcon) },
         )
     }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailScreen.kt
@@ -1,50 +1,35 @@
 package com.neki.android.feature.archive.impl.photo_detail
 
-import androidx.compose.animation.core.spring
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.setValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil3.compose.AsyncImage
 import com.neki.android.core.designsystem.DevicePreview
-import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
 import com.neki.android.core.designsystem.topbar.BackTitleTopBar
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.model.Photo
 import com.neki.android.core.navigation.result.LocalResultEventBus
-import com.neki.android.feature.archive.api.PhotoDetailResult
 import com.neki.android.core.ui.component.LoadingDialog
 import com.neki.android.core.ui.compose.collectWithLifecycle
 import com.neki.android.core.ui.toast.NekiToast
+import com.neki.android.feature.archive.api.PhotoDetailResult
 import com.neki.android.feature.archive.impl.component.DeletePhotoDialog
 import com.neki.android.feature.archive.impl.photo_detail.component.PhotoDetailActionBar
+import com.neki.android.feature.archive.impl.photo_detail.component.PhotoDetailImageItem
 import com.neki.android.feature.archive.impl.util.ImageDownloader
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -105,103 +90,59 @@ internal fun PhotoDetailScreen(
     onIntent: (PhotoDetailIntent) -> Unit = {},
     pagerState: PagerState = rememberPagerState { Int.MAX_VALUE },
 ) {
-    val density = LocalDensity.current
-    var actionBarHeightPx by remember { mutableIntStateOf(0) }
-    val actionBarHeight = with(density) { actionBarHeightPx.toDp() }
+    val isMemoActive = uiState.currentMemoMode == MemoMode.Expanded ||
+        uiState.currentMemoMode == MemoMode.Editing
 
-    Box(
+    Column(
         modifier = Modifier
             .fillMaxSize()
             .background(NekiTheme.colorScheme.white),
     ) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            BackTitleTopBar(
-                title = uiState.photo.date,
-                onBack = { onIntent(PhotoDetailIntent.ClickBackIcon) },
-            )
-
-            val isMemoActive = uiState.memoMode == MemoMode.Expanded ||
-                uiState.memoMode == MemoMode.Editing
-
-            HorizontalPager(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-                state = pagerState,
-                beyondViewportPageCount = 1,
-                userScrollEnabled = !isMemoActive,
-            ) { page ->
-                val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
-                Box {
-                    AsyncImage(
-                        modifier = Modifier.fillMaxSize(),
-                        model = uiState.photos.getOrNull(index)?.imageUrl,
-                        contentDescription = null,
-                        contentScale = ContentScale.Fit,
-                    )
-                    if (!isMemoActive) {
-                        Row(modifier = Modifier.matchParentSize()) {
-                            Box(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .fillMaxHeight()
-                                    .noRippleClickableSingle {
-                                        if (!pagerState.isScrollInProgress) {
-                                            onIntent(PhotoDetailIntent.ClickLeftPhoto)
-                                        }
-                                    },
-                            )
-                            Box(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .fillMaxHeight()
-                                    .noRippleClickableSingle {
-                                        if (!pagerState.isScrollInProgress) {
-                                            onIntent(PhotoDetailIntent.ClickRightPhoto)
-                                        }
-                                    },
-                            )
-                        }
-                    }
-                }
-            }
-
-            Spacer(modifier = Modifier.height(actionBarHeight))
-        }
-
-        // Expanded/Editing 모드일 때 dim 오버레이
-        AnimatedVisibility(
-            visible = uiState.memoMode == MemoMode.Expanded || uiState.memoMode == MemoMode.Editing,
-            enter = fadeIn(),
-            exit = fadeOut(),
-        ) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color(0x80202227))
-                    .noRippleClickableSingle { onIntent(PhotoDetailIntent.ClickMemoFold) },
-            )
-        }
-
-        PhotoDetailActionBar(
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .onSizeChanged {
-                    if (uiState.memoMode == MemoMode.Closed) actionBarHeightPx = it.height
-                },
-            isFavorite = uiState.photo.isFavorite,
-            memo = uiState.memo,
-            memoMode = uiState.memoMode,
-            onClickDownload = { onIntent(PhotoDetailIntent.ClickDownloadIcon) },
-            onClickFavorite = { onIntent(PhotoDetailIntent.ClickFavoriteIcon) },
-            onClickMemo = { onIntent(PhotoDetailIntent.ClickMemoIcon) },
-            onClickMemoMore = { onIntent(PhotoDetailIntent.ClickMemoMore) },
-            onClickMemoText = { onIntent(PhotoDetailIntent.ClickMemoText) },
-            onClickMemoFold = { onIntent(PhotoDetailIntent.ClickMemoFold) },
-            onClickMemoCancel = { onIntent(PhotoDetailIntent.ClickMemoCancel) },
-            onClickMemoDone = { onIntent(PhotoDetailIntent.ClickMemoDone(it)) },
-            onClickDelete = { onIntent(PhotoDetailIntent.ClickDeleteIcon) },
+        BackTitleTopBar(
+            title = uiState.photo.date,
+            onBack = { onIntent(PhotoDetailIntent.ClickBackIcon) },
         )
+
+        HorizontalPager(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            state = pagerState,
+            beyondViewportPageCount = 1,
+            userScrollEnabled = !isMemoActive,
+        ) { page ->
+            val index = if (uiState.photos.isEmpty()) 0 else page % uiState.photos.size
+            val photo = uiState.photos.getOrNull(index)
+            val pageMemoMode = uiState.memoModeOf(photo?.id ?: 0L)
+            val pageMemo = if (index == uiState.currentIndex) uiState.memo
+            else photo?.memo.orEmpty()
+
+            PhotoDetailImageItem(
+                imageUrl = photo?.imageUrl,
+                memo = pageMemo,
+                memoMode = pageMemoMode,
+                isScrollInProgress = pagerState.isScrollInProgress,
+                isTapEnabled = pageMemoMode != MemoMode.Expanded && pageMemoMode != MemoMode.Editing,
+                onClickLeft = { onIntent(PhotoDetailIntent.ClickLeftPhoto) },
+                onClickRight = { onIntent(PhotoDetailIntent.ClickRightPhoto) },
+                onClickMemoMore = { onIntent(PhotoDetailIntent.ClickMemoMore) },
+                onClickMemoText = { onIntent(PhotoDetailIntent.ClickMemoText) },
+                onClickMemoFold = { onIntent(PhotoDetailIntent.ClickMemoFold) },
+                onClickMemoCancel = { onIntent(PhotoDetailIntent.ClickMemoCancel) },
+                onClickMemoDone = { onIntent(PhotoDetailIntent.ClickMemoDone(it)) },
+                onMemoTextChanged = { onIntent(PhotoDetailIntent.MemoTextChanged(it)) },
+            )
+        }
+
+        AnimatedVisibility(visible = uiState.currentMemoMode != MemoMode.Editing) {
+            PhotoDetailActionBar(
+                isFavorite = uiState.photo.isFavorite,
+                onClickDownload = { onIntent(PhotoDetailIntent.ClickDownloadIcon) },
+                onClickFavorite = { onIntent(PhotoDetailIntent.ClickFavoriteIcon) },
+                onClickMemo = { onIntent(PhotoDetailIntent.ClickMemoIcon) },
+                onClickDelete = { onIntent(PhotoDetailIntent.ClickDeleteIcon) },
+            )
+        }
     }
 
     if (uiState.isShowDeleteDialog) {

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
@@ -75,7 +75,12 @@ class PhotoDetailViewModel @AssistedInject constructor(
     ) {
         when (intent) {
             // TopBar Intent
-            PhotoDetailIntent.ClickBackIcon -> postSideEffect(PhotoDetailSideEffect.NavigateBack)
+            PhotoDetailIntent.ClickBackIcon -> {
+                if (state.memo != state.photo.memo) {
+                    saveMemo(state, reduce, postSideEffect)
+                }
+                postSideEffect(PhotoDetailSideEffect.NavigateBack)
+            }
 
             // Pager Intent
             PhotoDetailIntent.ClickLeftPhoto -> {
@@ -92,7 +97,6 @@ class PhotoDetailViewModel @AssistedInject constructor(
                     copy(
                         currentPage = intent.page,
                         memo = photos.getOrNull(newIndex)?.memo.orEmpty(),
-                        memoMode = if (memoMode == MemoMode.Preview) MemoMode.Preview else MemoMode.Closed,
                     )
                 }
                 preloadIfNeeded(reduce)
@@ -117,16 +121,40 @@ class PhotoDetailViewModel @AssistedInject constructor(
             }
 
             // Memo Intent
+            is PhotoDetailIntent.MemoTextChanged -> reduce { copy(memo = intent.text) }
             PhotoDetailIntent.ClickMemoIcon -> reduce {
-                copy(memoMode = if (memoMode == MemoMode.Closed) MemoMode.Preview else MemoMode.Closed)
+                val photoId = photo.id
+                val current = memoModeOf(photoId)
+                val newMode = if (current == MemoMode.Closed) MemoMode.Preview else MemoMode.Closed
+                copy(memoModes = memoModes + (photoId to newMode))
             }
-            PhotoDetailIntent.ClickMemoMore -> reduce { copy(memoMode = MemoMode.Expanded) }
-            PhotoDetailIntent.ClickMemoFold -> reduce { copy(memoMode = MemoMode.Preview) }
-            PhotoDetailIntent.ClickMemoText -> reduce { copy(memoMode = MemoMode.Editing) }
-            PhotoDetailIntent.ClickMemoCancel -> reduce { copy(memoMode = MemoMode.Preview) }
+            PhotoDetailIntent.ClickMemoMore -> reduce {
+                copy(memoModes = memoModes + (photo.id to MemoMode.Expanded))
+            }
+            PhotoDetailIntent.ClickMemoText -> reduce {
+                copy(memoModes = memoModes + (photo.id to MemoMode.Editing))
+            }
+            PhotoDetailIntent.ClickMemoFold -> reduce {
+                copy(
+                    memo = photo.memo,
+                    memoModes = memoModes + (photo.id to MemoMode.Preview),
+                )
+            }
+            PhotoDetailIntent.ClickMemoCancel -> reduce {
+                copy(
+                    memo = photo.memo,
+                    memoModes = memoModes + (photo.id to MemoMode.Preview),
+                )
+            }
             is PhotoDetailIntent.ClickMemoDone -> {
-                reduce { copy(memo = intent.memo, memoMode = MemoMode.Preview) }
-                // TODO: 메모 저장 API 호출
+                val photoId = state.photo.id
+                reduce {
+                    copy(
+                        memo = intent.memo,
+                        memoModes = memoModes + (photoId to MemoMode.Preview),
+                    )
+                }
+                saveMemo(state.copy(memo = intent.memo), reduce, postSideEffect)
             }
 
             PhotoDetailIntent.ClickDeleteIcon -> reduce { copy(isShowDeleteDialog = true) }
@@ -135,6 +163,39 @@ class PhotoDetailViewModel @AssistedInject constructor(
             PhotoDetailIntent.DismissDeleteDialog -> reduce { copy(isShowDeleteDialog = false) }
             PhotoDetailIntent.ClickDeleteDialogCancelButton -> reduce { copy(isShowDeleteDialog = false) }
             PhotoDetailIntent.ClickDeleteDialogConfirmButton -> handleDelete(state, reduce, postSideEffect)
+        }
+    }
+
+    private fun saveMemo(
+        state: PhotoDetailState,
+        reduce: (PhotoDetailState.() -> PhotoDetailState) -> Unit,
+        postSideEffect: (PhotoDetailSideEffect) -> Unit,
+    ) {
+        val photoId = state.photo.id
+        val newMemo = state.memo
+        val oldMemo = state.photo.memo
+        if (newMemo == oldMemo) return
+        reduce {
+            copy(
+                photos = photos.map { p ->
+                    if (p.id == photoId) p.copy(memo = newMemo) else p
+                },
+            )
+        }
+        viewModelScope.launch {
+            photoRepository.updateMemo(photoId, newMemo)
+                .onFailure { e ->
+                    Timber.e(e, "updateMemo failed")
+                    reduce {
+                        copy(
+                            memo = oldMemo,
+                            photos = photos.map { p ->
+                                if (p.id == photoId) p.copy(memo = oldMemo) else p
+                            },
+                        )
+                    }
+                    postSideEffect(PhotoDetailSideEffect.ShowToastMessage("메모 저장에 실패했어요"))
+                }
         }
     }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
@@ -36,6 +36,7 @@ class PhotoDetailViewModel @AssistedInject constructor(
             initialState = PhotoDetailState(
                 photos = key.photos,
                 currentPage = key.initialIndex,
+                memo = key.photos.getOrNull(key.initialIndex)?.memo.orEmpty(),
             ),
             onIntent = ::onIntent,
         )
@@ -86,7 +87,14 @@ class PhotoDetailViewModel @AssistedInject constructor(
             PhotoDetailIntent.ClickRightPhoto -> postSideEffect(PhotoDetailSideEffect.AnimateToPage(state.currentPage + 1))
 
             is PhotoDetailIntent.PageChanged -> {
-                reduce { copy(currentPage = intent.page) }
+                reduce {
+                    val newIndex = if (photos.isEmpty()) 0 else intent.page % photos.size
+                    copy(
+                        currentPage = intent.page,
+                        memo = photos.getOrNull(newIndex)?.memo.orEmpty(),
+                        memoMode = if (memoMode == MemoMode.Preview) MemoMode.Preview else MemoMode.Closed,
+                    )
+                }
                 preloadIfNeeded(reduce)
             }
 
@@ -106,6 +114,19 @@ class PhotoDetailViewModel @AssistedInject constructor(
                         },
                     )
                 }
+            }
+
+            // Memo Intent
+            PhotoDetailIntent.ClickMemoIcon -> reduce {
+                copy(memoMode = if (memoMode == MemoMode.Closed) MemoMode.Preview else MemoMode.Closed)
+            }
+            PhotoDetailIntent.ClickMemoMore -> reduce { copy(memoMode = MemoMode.Expanded) }
+            PhotoDetailIntent.ClickMemoFold -> reduce { copy(memoMode = MemoMode.Preview) }
+            PhotoDetailIntent.ClickMemoText -> reduce { copy(memoMode = MemoMode.Editing) }
+            PhotoDetailIntent.ClickMemoCancel -> reduce { copy(memoMode = MemoMode.Preview) }
+            is PhotoDetailIntent.ClickMemoDone -> {
+                reduce { copy(memo = intent.memo, memoMode = MemoMode.Preview) }
+                // TODO: 메모 저장 API 호출
             }
 
             PhotoDetailIntent.ClickDeleteIcon -> reduce { copy(isShowDeleteDialog = true) }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
@@ -11,6 +11,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -76,9 +77,6 @@ class PhotoDetailViewModel @AssistedInject constructor(
         when (intent) {
             // TopBar Intent
             PhotoDetailIntent.ClickBackIcon -> {
-                if (state.memo != state.photo.memo) {
-                    saveMemo(state, reduce, postSideEffect)
-                }
                 postSideEffect(PhotoDetailSideEffect.NavigateBack)
             }
 
@@ -126,24 +124,24 @@ class PhotoDetailViewModel @AssistedInject constructor(
                 val photoId = photo.id
                 val current = memoModeOf(photoId)
                 val newMode = if (current == MemoMode.Closed) MemoMode.Preview else MemoMode.Closed
-                copy(memoModes = memoModes + (photoId to newMode))
+                copy(memoModes = (memoModes + (photoId to newMode)).toImmutableMap())
             }
             PhotoDetailIntent.ClickMemoMore -> reduce {
-                copy(memoModes = memoModes + (photo.id to MemoMode.Expanded))
+                copy(memoModes = (memoModes + (photo.id to MemoMode.Expanded)).toImmutableMap())
             }
             PhotoDetailIntent.ClickMemoText -> reduce {
-                copy(memoModes = memoModes + (photo.id to MemoMode.Editing))
+                copy(memoModes = (memoModes + (photo.id to MemoMode.Editing)).toImmutableMap())
             }
             PhotoDetailIntent.ClickMemoFold -> reduce {
                 copy(
                     memo = photo.memo,
-                    memoModes = memoModes + (photo.id to MemoMode.Preview),
+                    memoModes = (memoModes + (photo.id to MemoMode.Preview)).toImmutableMap(),
                 )
             }
             PhotoDetailIntent.ClickMemoCancel -> reduce {
                 copy(
                     memo = photo.memo,
-                    memoModes = memoModes + (photo.id to MemoMode.Preview),
+                    memoModes = (memoModes + (photo.id to MemoMode.Preview)).toImmutableMap(),
                 )
             }
             is PhotoDetailIntent.ClickMemoDone -> {
@@ -151,7 +149,7 @@ class PhotoDetailViewModel @AssistedInject constructor(
                 reduce {
                     copy(
                         memo = intent.memo,
-                        memoModes = memoModes + (photoId to MemoMode.Preview),
+                        memoModes = (memoModes + (photoId to MemoMode.Preview)).toImmutableMap(),
                     )
                 }
                 saveMemo(state.copy(memo = intent.memo), reduce, postSideEffect)
@@ -184,6 +182,9 @@ class PhotoDetailViewModel @AssistedInject constructor(
         }
         viewModelScope.launch {
             photoRepository.updateMemo(photoId, newMemo)
+                .onSuccess {
+                    postSideEffect(PhotoDetailSideEffect.NotifyPhotoUpdated)
+                }
                 .onFailure { e ->
                     Timber.e(e, "updateMemo failed")
                     reduce {

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
@@ -107,7 +107,7 @@ internal fun MemoTextField(
                     start = 16.dp,
                     end = 16.dp,
                     top = 20.dp,
-                    bottom = if (memoMode == MemoMode.Editing) 0.dp else 20.dp,
+                    bottom = if (memoMode == MemoMode.Editing) 8.dp else 20.dp,
                 ),
         ) {
             when (memoMode) {
@@ -212,9 +212,9 @@ private fun MemoEditingContent(
         modifier = Modifier
             .fillMaxWidth()
             .focusRequester(focusRequester),
-        textStyle = NekiTheme.typography.body16Medium,
+        textStyle = NekiTheme.typography.body16Medium.copy(color = NekiTheme.colorScheme.gray700),
         inputTransformation = InputTransformation.maxLength(100),
-        cursorBrush = SolidColor(NekiTheme.colorScheme.gray900),
+        cursorBrush = SolidColor(NekiTheme.colorScheme.gray800),
         decorator = { innerTextField -> innerTextField() },
     )
     Spacer(modifier = Modifier.height(8.dp))

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
@@ -223,20 +223,25 @@ private fun MemoEditingContent(
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
             Text(
                 text = "$charCount/100",
                 style = NekiTheme.typography.caption12Regular,
                 color = NekiTheme.colorScheme.gray300,
             )
-            Text(
-                text = "전체 지우기",
-                modifier = Modifier.noRippleClickableSingle {
-                    memoState.edit { replace(0, length, "") }
-                },
-                style = NekiTheme.typography.caption12Medium,
-                color = NekiTheme.colorScheme.gray200,
-            )
+            NekiTextButton(
+                onClick = { memoState.edit { replace(0, length, "") } },
+                contentPadding = PaddingValues(10.dp),
+            ) {
+                Text(
+                    text = "전체 지우기",
+                    style = NekiTheme.typography.caption12Medium,
+                    color = NekiTheme.colorScheme.gray200,
+                )
+            }
         }
         Row(
             horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
@@ -72,9 +72,11 @@ internal fun MemoTextField(
         previousMemoMode = memoMode
     }
 
-    LaunchedEffect(memoState) {
-        snapshotFlow { memoState.text.toString() }
-            .collect { text -> onMemoTextChanged(text) }
+    LaunchedEffect(memoState, memoMode) {
+        if (memoMode == MemoMode.Editing) {
+            snapshotFlow { memoState.text.toString() }
+                .collect { text -> onMemoTextChanged(text) }
+        }
     }
 
     Column(

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/MemoTextField.kt
@@ -1,0 +1,360 @@
+package com.neki.android.feature.archive.impl.photo_detail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.maxLength
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.neki.android.core.designsystem.ComponentPreview
+import com.neki.android.core.designsystem.button.NekiTextButton
+import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
+import com.neki.android.core.designsystem.ui.theme.NekiTheme
+import com.neki.android.feature.archive.impl.photo_detail.MemoMode
+
+@Composable
+internal fun MemoTextField(
+    memo: String,
+    memoMode: MemoMode,
+    onClickMemoMore: () -> Unit,
+    onClickMemoFold: () -> Unit,
+    onClickMemoText: () -> Unit,
+    onClickMemoCancel: () -> Unit,
+    onClickMemoDone: (String) -> Unit,
+    onMemoTextChanged: (String) -> Unit,
+) {
+    val memoState = remember { TextFieldState(initialText = memo) }
+    val focusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    var previousMemoMode by remember { mutableStateOf(memoMode) }
+
+    LaunchedEffect(memo, memoMode) {
+        if (memoMode != MemoMode.Editing) {
+            memoState.edit { replace(0, length, memo) }
+        }
+    }
+
+    LaunchedEffect(memoMode) {
+        if (memoMode == MemoMode.Editing) {
+            memoState.edit { replace(0, length, memo) }
+            focusRequester.requestFocus()
+        } else if (previousMemoMode == MemoMode.Editing) {
+            keyboardController?.hide()
+        }
+        previousMemoMode = memoMode
+    }
+
+    LaunchedEffect(memoState) {
+        snapshotFlow { memoState.text.toString() }
+            .collect { text -> onMemoTextChanged(text) }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                when (memoMode) {
+                    MemoMode.Editing -> NekiTheme.colorScheme.gray25
+                    else -> NekiTheme.colorScheme.white
+                },
+            ),
+    ) {
+        HorizontalDivider(
+            modifier = Modifier.fillMaxWidth(),
+            thickness = 1.dp,
+            color = NekiTheme.colorScheme.gray75,
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(
+                    when (memoMode) {
+                        MemoMode.Preview, MemoMode.Expanded -> Modifier.noRippleClickableSingle { onClickMemoText() }
+                        else -> Modifier
+                    },
+                )
+                .padding(
+                    start = 16.dp,
+                    end = 16.dp,
+                    top = 20.dp,
+                    bottom = if (memoMode == MemoMode.Editing) 0.dp else 20.dp,
+                ),
+        ) {
+            when (memoMode) {
+                MemoMode.Closed -> Unit
+                MemoMode.Preview -> MemoPreviewContent(
+                    memo = memo,
+                    onClickMemoMore = onClickMemoMore,
+                )
+
+                MemoMode.Expanded -> MemoExpandedContent(
+                    memoState = memoState,
+                    focusRequester = focusRequester,
+                    onClickMemoText = onClickMemoText,
+                    onClickMemoFold = onClickMemoFold,
+                )
+
+                MemoMode.Editing -> MemoEditingContent(
+                    memoState = memoState,
+                    focusRequester = focusRequester,
+                    onClickMemoCancel = onClickMemoCancel,
+                    onClickMemoDone = onClickMemoDone,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MemoPreviewContent(
+    memo: String,
+    onClickMemoMore: () -> Unit,
+) {
+    var hasOverflow by remember { mutableStateOf(false) }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        Text(
+            text = memo.ifEmpty { "자유롭게 메모를 입력해주세요. (최대 100자)" },
+            modifier = Modifier.weight(1f),
+            style = NekiTheme.typography.body16Regular,
+            color = if (memo.isEmpty()) NekiTheme.colorScheme.gray300
+            else NekiTheme.colorScheme.gray700,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            onTextLayout = { result -> hasOverflow = result.hasVisualOverflow },
+        )
+        if (hasOverflow) {
+            Text(
+                text = "더보기",
+                modifier = Modifier.noRippleClickableSingle { onClickMemoMore() },
+                style = NekiTheme.typography.body16Medium,
+                color = NekiTheme.colorScheme.gray300,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.MemoExpandedContent(
+    memoState: TextFieldState,
+    focusRequester: FocusRequester,
+    onClickMemoText: () -> Unit,
+    onClickMemoFold: () -> Unit,
+) {
+    BasicTextField(
+        state = memoState,
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusRequester(focusRequester)
+            .onFocusChanged {
+                if (it.isFocused) onClickMemoText()
+            },
+        textStyle = NekiTheme.typography.body16Medium,
+        readOnly = true,
+        inputTransformation = InputTransformation.maxLength(100),
+        cursorBrush = SolidColor(Color.Transparent),
+        decorator = { innerTextField -> innerTextField() },
+    )
+    Text(
+        text = "메모 접기",
+        modifier = Modifier
+            .align(Alignment.End)
+            .noRippleClickableSingle { onClickMemoFold() },
+        style = NekiTheme.typography.body16Medium,
+        color = NekiTheme.colorScheme.gray200,
+    )
+}
+
+@Composable
+private fun MemoEditingContent(
+    memoState: TextFieldState,
+    focusRequester: FocusRequester,
+    onClickMemoCancel: () -> Unit,
+    onClickMemoDone: (String) -> Unit,
+) {
+    val charCount = memoState.text.length
+
+    BasicTextField(
+        state = memoState,
+        modifier = Modifier
+            .fillMaxWidth()
+            .focusRequester(focusRequester),
+        textStyle = NekiTheme.typography.body16Medium,
+        inputTransformation = InputTransformation.maxLength(100),
+        cursorBrush = SolidColor(NekiTheme.colorScheme.gray900),
+        decorator = { innerTextField -> innerTextField() },
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "$charCount/100",
+                style = NekiTheme.typography.caption12Regular,
+                color = NekiTheme.colorScheme.gray300,
+            )
+            Text(
+                text = "전체 지우기",
+                modifier = Modifier.noRippleClickableSingle {
+                    memoState.edit { replace(0, length, "") }
+                },
+                style = NekiTheme.typography.caption12Medium,
+                color = NekiTheme.colorScheme.gray200,
+            )
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            NekiTextButton(
+                onClick = onClickMemoCancel,
+                contentPadding = PaddingValues(10.dp),
+            ) {
+                Text(
+                    text = "취소",
+                    style = NekiTheme.typography.body16SemiBold,
+                    color = NekiTheme.colorScheme.gray800,
+                )
+            }
+            NekiTextButton(
+                onClick = { onClickMemoDone(memoState.text.toString()) },
+                contentPadding = PaddingValues(10.dp),
+            ) {
+                Text(
+                    text = "완료",
+                    style = NekiTheme.typography.body16SemiBold,
+                    color = NekiTheme.colorScheme.primary500,
+                )
+            }
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun MemoTextFieldPreviewPreview() {
+    NekiTheme {
+        Box {
+            MemoTextField(
+                memo = "짧은 메모",
+                memoMode = MemoMode.Preview,
+                onClickMemoMore = {},
+                onClickMemoFold = {},
+                onClickMemoText = {},
+                onClickMemoCancel = {},
+                onClickMemoDone = {},
+                onMemoTextChanged = {},
+            )
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun MemoTextFieldPreviewOverflowPreview() {
+    NekiTheme {
+        Box {
+            MemoTextField(
+                memo = "재밌었던 날인데 메모가 길어서 한 줄에 다 안 들어갈 수도 있어요 이렇게 길면 더보기가 나와야 해요",
+                memoMode = MemoMode.Preview,
+                onClickMemoMore = {},
+                onClickMemoFold = {},
+                onClickMemoText = {},
+                onClickMemoCancel = {},
+                onClickMemoDone = {},
+                onMemoTextChanged = {},
+            )
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun MemoTextFieldExpandedPreview() {
+    NekiTheme {
+        Box {
+            MemoTextField(
+                memo = "재밌었던 날인데 메모가 길어서 한 줄에 다 안 들어갈 수도 있어요",
+                memoMode = MemoMode.Expanded,
+                onClickMemoMore = {},
+                onClickMemoFold = {},
+                onClickMemoText = {},
+                onClickMemoCancel = {},
+                onClickMemoDone = {},
+                onMemoTextChanged = {},
+            )
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun MemoTextFieldEditingPreview() {
+    NekiTheme {
+        Box {
+            MemoTextField(
+                memo = "재밌었던 날",
+                memoMode = MemoMode.Editing,
+                onClickMemoMore = {},
+                onClickMemoFold = {},
+                onClickMemoText = {},
+                onClickMemoCancel = {},
+                onClickMemoDone = {},
+                onMemoTextChanged = {},
+            )
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun MemoTextFieldEmptyPreview() {
+    NekiTheme {
+        Box {
+            MemoTextField(
+                memo = "",
+                memoMode = MemoMode.Preview,
+                onClickMemoMore = {},
+                onClickMemoFold = {},
+                onClickMemoText = {},
+                onClickMemoCancel = {},
+                onClickMemoDone = {},
+                onMemoTextChanged = {},
+            )
+        }
+    }
+}

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailActionBar.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailActionBar.kt
@@ -1,93 +1,411 @@
 package com.neki.android.feature.archive.impl.photo_detail.component
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.input.InputTransformation
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.maxLength
+import androidx.compose.ui.graphics.Color
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.neki.android.core.designsystem.ComponentPreview
 import com.neki.android.core.designsystem.R
 import com.neki.android.core.designsystem.actionbar.NekiBothSidesActionBar
 import com.neki.android.core.designsystem.button.NekiIconButton
+import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
+import com.neki.android.feature.archive.impl.photo_detail.MemoMode
 
 @Composable
 internal fun PhotoDetailActionBar(
     isFavorite: Boolean,
+    memo: String,
+    memoMode: MemoMode,
     modifier: Modifier = Modifier,
     onClickDownload: () -> Unit = {},
     onClickFavorite: () -> Unit = {},
+    onClickMemo: () -> Unit = {},
+    onClickMemoMore: () -> Unit = {},
+    onClickMemoText: () -> Unit = {},
+    onClickMemoFold: () -> Unit = {},
+    onClickMemoCancel: () -> Unit = {},
+    onClickMemoDone: (String) -> Unit = {},
     onClickDelete: () -> Unit = {},
 ) {
-    NekiBothSidesActionBar(
-        modifier = modifier.fillMaxWidth(),
-        startContent = {
-            Row {
-                NekiIconButton(
-                    modifier = Modifier.padding(8.dp),
-                    onClick = onClickDownload,
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(NekiTheme.colorScheme.white),
+    ) {
+        AnimatedVisibility(
+            visible = memoMode != MemoMode.Closed,
+            enter = expandVertically(expandFrom = Alignment.Top),
+            exit = shrinkVertically(shrinkTowards = Alignment.Top),
+        ) {
+            MemoTextField(
+                memo = memo,
+                memoMode = memoMode,
+                onClickMemoMore = onClickMemoMore,
+                onClickMemoFold = onClickMemoFold,
+                onClickMemoText = onClickMemoText,
+                onClickMemoCancel = onClickMemoCancel,
+                onClickMemoDone = onClickMemoDone,
+            )
+        }
+
+        // 아이콘 바 (Editing 모드에서는 숨김)
+        if (memoMode != MemoMode.Editing) {
+            NekiBothSidesActionBar(
+                startContent = {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        NekiIconButton(
+                            modifier = Modifier.padding(8.dp),
+                            onClick = onClickDownload,
+                        ) {
+                            Icon(
+                                modifier = Modifier.size(28.dp),
+                                imageVector = ImageVector.vectorResource(R.drawable.icon_download),
+                                contentDescription = null,
+                                tint = NekiTheme.colorScheme.gray700,
+                            )
+                        }
+                        NekiIconButton(
+                            modifier = Modifier.padding(8.dp),
+                            onClick = onClickFavorite,
+                        ) {
+                            Icon(
+                                modifier = Modifier.size(28.dp),
+                                imageVector = ImageVector.vectorResource(
+                                    if (isFavorite) R.drawable.icon_favorite_filled
+                                    else R.drawable.icon_favorite_stroked,
+                                ),
+                                contentDescription = null,
+                                tint = if (isFavorite) NekiTheme.colorScheme.primary400
+                                else NekiTheme.colorScheme.gray700,
+                            )
+                        }
+                        NekiIconButton(
+                            modifier = Modifier.padding(8.dp),
+                            onClick = onClickMemo,
+                        ) {
+                            // TODO: ic_note 아이콘 리소스 추가 후 교체
+                            Icon(
+                                modifier = Modifier.size(28.dp),
+                                imageVector = ImageVector.vectorResource(R.drawable.icon_bookmark_stroked),
+                                contentDescription = null,
+                                tint = NekiTheme.colorScheme.gray700,
+                            )
+                        }
+                    }
+                },
+                endContent = {
+                    NekiIconButton(
+                        modifier = Modifier.padding(8.dp),
+                        onClick = onClickDelete,
+                    ) {
+                        Icon(
+                            modifier = Modifier.size(28.dp),
+                            imageVector = ImageVector.vectorResource(R.drawable.icon_trash),
+                            contentDescription = null,
+                            tint = NekiTheme.colorScheme.gray700,
+                        )
+                    }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun MemoTextField(
+    memo: String,
+    memoMode: MemoMode,
+    onClickMemoMore: () -> Unit,
+    onClickMemoFold: () -> Unit,
+    onClickMemoText: () -> Unit,
+    onClickMemoCancel: () -> Unit,
+    onClickMemoDone: (String) -> Unit,
+) {
+    val isEditing = memoMode == MemoMode.Editing
+    val isExpanded = memoMode == MemoMode.Expanded
+    val isPreview = memoMode == MemoMode.Preview
+    val memoState = remember { TextFieldState(initialText = memo) }
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(memo, memoMode) {
+        if (memoMode != MemoMode.Editing) {
+            memoState.edit { replace(0, length, memo) }
+        }
+    }
+
+    LaunchedEffect(memoMode) {
+        if (memoMode == MemoMode.Editing) {
+            memoState.edit { replace(0, length, memo) }
+            focusRequester.requestFocus()
+        }
+    }
+
+    val textFieldStyle = TextStyle(
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Medium,
+        lineHeight = 24.sp,
+        letterSpacing = (-0.32).sp,
+        color = NekiTheme.colorScheme.gray700,
+        lineHeightStyle = LineHeightStyle(
+            alignment = LineHeightStyle.Alignment.Center,
+            trim = LineHeightStyle.Trim.None,
+        ),
+    )
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(if (isEditing) NekiTheme.colorScheme.gray25 else NekiTheme.colorScheme.white),
+    ) {
+        HorizontalDivider(
+            modifier = Modifier.fillMaxWidth(),
+            thickness = 1.dp,
+            color = NekiTheme.colorScheme.gray75,
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .then(
+                    if (isPreview || isExpanded) Modifier.noRippleClickableSingle { onClickMemoText() } else Modifier,
+                )
+                .padding(
+                    start = if (isEditing) 20.dp else 12.dp,
+                    end = if (isEditing) 16.dp else 12.dp,
+                    top = if (isPreview) 8.dp else 16.dp,
+                    bottom = if (isEditing) 8.dp else 8.dp,
+                ),
+        ) {
+            if (isPreview) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    Icon(
-                        modifier = Modifier.size(28.dp),
-                        imageVector = ImageVector.vectorResource(R.drawable.icon_download),
-                        contentDescription = null,
-                        tint = NekiTheme.colorScheme.gray700,
-                    )
-                }
-                NekiIconButton(
-                    modifier = Modifier.padding(8.dp),
-                    onClick = onClickFavorite,
-                ) {
-                    Icon(
-                        modifier = Modifier.size(28.dp),
-                        imageVector = ImageVector.vectorResource(
-                            if (isFavorite) R.drawable.icon_favorite_filled
-                            else R.drawable.icon_favorite_stroked,
+                    Text(
+                        text = memo.ifEmpty { "메모 없음" },
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(horizontal = 8.dp),
+                        style = textFieldStyle.copy(
+                            color = if (memo.isEmpty()) NekiTheme.colorScheme.gray300
+                            else NekiTheme.colorScheme.gray700,
                         ),
-                        contentDescription = null,
-                        tint = if (isFavorite) NekiTheme.colorScheme.primary400
-                        else NekiTheme.colorScheme.gray700,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = "더보기",
+                        modifier = Modifier
+                            .noRippleClickableSingle { onClickMemoMore() }
+                            .padding(8.dp),
+                        style = TextStyle(
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Medium,
+                            lineHeight = 24.sp,
+                            letterSpacing = (-0.32).sp,
+                            color = NekiTheme.colorScheme.gray200,
+                        ),
                     )
                 }
-            }
-        },
-        endContent = {
-            NekiIconButton(
-                modifier = Modifier.padding(8.dp),
-                onClick = onClickDelete,
-            ) {
-                Icon(
-                    modifier = Modifier.size(28.dp),
-                    imageVector = ImageVector.vectorResource(R.drawable.icon_trash),
-                    contentDescription = null,
-                    tint = NekiTheme.colorScheme.gray700,
+            } else {
+                BasicTextField(
+                    state = memoState,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .then(if (isExpanded) Modifier.padding(horizontal = 8.dp) else Modifier)
+                        .focusRequester(focusRequester)
+                        .onFocusChanged {
+                            if (it.isFocused && isExpanded) onClickMemoText()
+                        },
+                    textStyle = textFieldStyle,
+                    readOnly = isExpanded,
+                    inputTransformation = InputTransformation.maxLength(100),
+                    cursorBrush = SolidColor(
+                        if (isEditing) NekiTheme.colorScheme.gray900 else Color.Transparent,
+                    ),
+                    decorator = { innerTextField ->
+                        Box {
+                            if (memoState.text.isEmpty()) {
+                                Text(
+                                    text = if (isEditing) "자유롭게 메모를 입력해주세요. (최대 100자)" else "메모 없음",
+                                    style = textFieldStyle.copy(color = NekiTheme.colorScheme.gray300),
+                                )
+                            }
+                            innerTextField()
+                        }
+                    },
                 )
             }
-        },
-    )
+
+            // Expanded: 메모 접기
+            if (isExpanded) {
+                Text(
+                    text = "메모 접기",
+                    modifier = Modifier
+                        .align(Alignment.End)
+                        .noRippleClickableSingle { onClickMemoFold() }
+                        .padding(start = 8.dp, end = 8.dp, bottom = 8.dp),
+                    style = TextStyle(
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Medium,
+                        lineHeight = 24.sp,
+                        letterSpacing = (-0.32).sp,
+                        color = NekiTheme.colorScheme.gray200,
+                    ),
+                )
+            }
+
+            // Editing: 카운터 + 전체지우기 + 취소/완료
+            if (isEditing) {
+                val charCount = memoState.text.length
+                val hasText = charCount > 0
+
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = "$charCount/100",
+                            style = TextStyle(
+                                fontSize = 12.sp,
+                                lineHeight = 16.sp,
+                                letterSpacing = (-0.24).sp,
+                                color = NekiTheme.colorScheme.gray300,
+                            ),
+                        )
+                        Text(
+                            text = "전체 지우기",
+                            modifier = Modifier
+                                .noRippleClickableSingle { memoState.edit { replace(0, length, "") } }
+                                .padding(8.dp),
+                            style = TextStyle(
+                                fontSize = 12.sp,
+                                fontWeight = FontWeight.Medium,
+                                lineHeight = 16.sp,
+                                letterSpacing = (-0.24).sp,
+                                color = if (hasText) NekiTheme.colorScheme.gray600
+                                else NekiTheme.colorScheme.gray200,
+                            ),
+                        )
+                    }
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = "취소",
+                            modifier = Modifier
+                                .noRippleClickableSingle { onClickMemoCancel() }
+                                .padding(vertical = 10.dp),
+                            style = TextStyle(
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                lineHeight = 24.sp,
+                                letterSpacing = (-0.32).sp,
+                                color = NekiTheme.colorScheme.gray800,
+                            ),
+                        )
+                        Text(
+                            text = "완료",
+                            modifier = Modifier
+                                .noRippleClickableSingle { onClickMemoDone(memoState.text.toString()) }
+                                .padding(vertical = 10.dp),
+                            style = TextStyle(
+                                fontSize = 16.sp,
+                                fontWeight = FontWeight.SemiBold,
+                                lineHeight = 24.sp,
+                                letterSpacing = (-0.32).sp,
+                                color = NekiTheme.colorScheme.primary500,
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    }
 }
 
 @ComponentPreview
 @Composable
-private fun PhotoDetailActionBarNotFavoritePreview() {
+private fun PhotoDetailActionBarClosedPreview() {
     NekiTheme {
         PhotoDetailActionBar(
             isFavorite = false,
+            memo = "",
+            memoMode = MemoMode.Closed,
         )
     }
 }
 
 @ComponentPreview
 @Composable
-private fun PhotoDetailActionBarFavoritePreview() {
+private fun PhotoDetailActionBarPreviewPreview() {
+    NekiTheme {
+        PhotoDetailActionBar(
+            isFavorite = false,
+            memo = "재밌었던 날인데 메모가 길어서 한 줄에 다 안 들어갈 수도 있어요",
+            memoMode = MemoMode.Preview,
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun PhotoDetailActionBarExpandedPreview() {
     NekiTheme {
         PhotoDetailActionBar(
             isFavorite = true,
+            memo = "재밌었던 날인데 메모가 길어서 한 줄에 다 안 들어갈 수도 있어요",
+            memoMode = MemoMode.Expanded,
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun PhotoDetailActionBarEditingPreview() {
+    NekiTheme {
+        PhotoDetailActionBar(
+            isFavorite = true,
+            memo = "재밌었던 날",
+            memoMode = MemoMode.Editing,
         )
     }
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailActionBar.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailActionBar.kt
@@ -1,365 +1,87 @@
 package com.neki.android.feature.archive.impl.photo_detail.component
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.animation.expandVertically
-import androidx.compose.animation.shrinkVertically
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.input.InputTransformation
-import androidx.compose.foundation.text.input.TextFieldState
-import androidx.compose.foundation.text.input.maxLength
-import androidx.compose.ui.graphics.Color
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.neki.android.core.designsystem.ComponentPreview
 import com.neki.android.core.designsystem.R
 import com.neki.android.core.designsystem.actionbar.NekiBothSidesActionBar
 import com.neki.android.core.designsystem.button.NekiIconButton
-import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
-import com.neki.android.feature.archive.impl.photo_detail.MemoMode
 
 @Composable
 internal fun PhotoDetailActionBar(
     isFavorite: Boolean,
-    memo: String,
-    memoMode: MemoMode,
     modifier: Modifier = Modifier,
     onClickDownload: () -> Unit = {},
     onClickFavorite: () -> Unit = {},
     onClickMemo: () -> Unit = {},
-    onClickMemoMore: () -> Unit = {},
-    onClickMemoText: () -> Unit = {},
-    onClickMemoFold: () -> Unit = {},
-    onClickMemoCancel: () -> Unit = {},
-    onClickMemoDone: (String) -> Unit = {},
     onClickDelete: () -> Unit = {},
 ) {
-    Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .background(NekiTheme.colorScheme.white),
-    ) {
-        AnimatedVisibility(
-            visible = memoMode != MemoMode.Closed,
-            enter = expandVertically(expandFrom = Alignment.Top),
-            exit = shrinkVertically(shrinkTowards = Alignment.Top),
-        ) {
-            MemoTextField(
-                memo = memo,
-                memoMode = memoMode,
-                onClickMemoMore = onClickMemoMore,
-                onClickMemoFold = onClickMemoFold,
-                onClickMemoText = onClickMemoText,
-                onClickMemoCancel = onClickMemoCancel,
-                onClickMemoDone = onClickMemoDone,
-            )
-        }
-
-        // 아이콘 바 (Editing 모드에서는 숨김)
-        if (memoMode != MemoMode.Editing) {
-            NekiBothSidesActionBar(
-                startContent = {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        NekiIconButton(
-                            modifier = Modifier.padding(8.dp),
-                            onClick = onClickDownload,
-                        ) {
-                            Icon(
-                                modifier = Modifier.size(28.dp),
-                                imageVector = ImageVector.vectorResource(R.drawable.icon_download),
-                                contentDescription = null,
-                                tint = NekiTheme.colorScheme.gray700,
-                            )
-                        }
-                        NekiIconButton(
-                            modifier = Modifier.padding(8.dp),
-                            onClick = onClickFavorite,
-                        ) {
-                            Icon(
-                                modifier = Modifier.size(28.dp),
-                                imageVector = ImageVector.vectorResource(
-                                    if (isFavorite) R.drawable.icon_favorite_filled
-                                    else R.drawable.icon_favorite_stroked,
-                                ),
-                                contentDescription = null,
-                                tint = if (isFavorite) NekiTheme.colorScheme.primary400
-                                else NekiTheme.colorScheme.gray700,
-                            )
-                        }
-                        NekiIconButton(
-                            modifier = Modifier.padding(8.dp),
-                            onClick = onClickMemo,
-                        ) {
-                            // TODO: ic_note 아이콘 리소스 추가 후 교체
-                            Icon(
-                                modifier = Modifier.size(28.dp),
-                                imageVector = ImageVector.vectorResource(R.drawable.icon_bookmark_stroked),
-                                contentDescription = null,
-                                tint = NekiTheme.colorScheme.gray700,
-                            )
-                        }
-                    }
-                },
-                endContent = {
-                    NekiIconButton(
-                        modifier = Modifier.padding(8.dp),
-                        onClick = onClickDelete,
-                    ) {
-                        Icon(
-                            modifier = Modifier.size(28.dp),
-                            imageVector = ImageVector.vectorResource(R.drawable.icon_trash),
-                            contentDescription = null,
-                            tint = NekiTheme.colorScheme.gray700,
-                        )
-                    }
-                },
-            )
-        }
-    }
-}
-
-@Composable
-private fun MemoTextField(
-    memo: String,
-    memoMode: MemoMode,
-    onClickMemoMore: () -> Unit,
-    onClickMemoFold: () -> Unit,
-    onClickMemoText: () -> Unit,
-    onClickMemoCancel: () -> Unit,
-    onClickMemoDone: (String) -> Unit,
-) {
-    val isEditing = memoMode == MemoMode.Editing
-    val isExpanded = memoMode == MemoMode.Expanded
-    val isPreview = memoMode == MemoMode.Preview
-    val memoState = remember { TextFieldState(initialText = memo) }
-    val focusRequester = remember { FocusRequester() }
-
-    LaunchedEffect(memo, memoMode) {
-        if (memoMode != MemoMode.Editing) {
-            memoState.edit { replace(0, length, memo) }
-        }
-    }
-
-    LaunchedEffect(memoMode) {
-        if (memoMode == MemoMode.Editing) {
-            memoState.edit { replace(0, length, memo) }
-            focusRequester.requestFocus()
-        }
-    }
-
-    val textFieldStyle = TextStyle(
-        fontSize = 16.sp,
-        fontWeight = FontWeight.Medium,
-        lineHeight = 24.sp,
-        letterSpacing = (-0.32).sp,
-        color = NekiTheme.colorScheme.gray700,
-        lineHeightStyle = LineHeightStyle(
-            alignment = LineHeightStyle.Alignment.Center,
-            trim = LineHeightStyle.Trim.None,
-        ),
+    NekiBothSidesActionBar(
+        modifier = modifier,
+        startContent = {
+            Row(
+                modifier = Modifier.padding(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                NekiIconButton(
+                    onClick = onClickDownload,
+                ) {
+                    Icon(
+                        modifier = Modifier.size(28.dp),
+                        imageVector = ImageVector.vectorResource(R.drawable.icon_download),
+                        contentDescription = null,
+                        tint = NekiTheme.colorScheme.gray700,
+                    )
+                }
+                NekiIconButton(
+                    onClick = onClickFavorite,
+                ) {
+                    Icon(
+                        modifier = Modifier.size(28.dp),
+                        imageVector = ImageVector.vectorResource(
+                            if (isFavorite) R.drawable.icon_favorite_filled
+                            else R.drawable.icon_favorite_stroked,
+                        ),
+                        contentDescription = null,
+                        tint = if (isFavorite) NekiTheme.colorScheme.primary400
+                        else NekiTheme.colorScheme.gray700,
+                    )
+                }
+                NekiIconButton(
+                    onClick = onClickMemo,
+                ) {
+                    Icon(
+                        modifier = Modifier.size(28.dp),
+                        imageVector = ImageVector.vectorResource(R.drawable.icon_memo),
+                        contentDescription = null,
+                        tint = NekiTheme.colorScheme.gray700,
+                    )
+                }
+            }
+        },
+        endContent = {
+            NekiIconButton(
+                modifier = Modifier.padding(8.dp),
+                onClick = onClickDelete,
+            ) {
+                Icon(
+                    modifier = Modifier.size(28.dp),
+                    imageVector = ImageVector.vectorResource(R.drawable.icon_trash),
+                    contentDescription = null,
+                    tint = NekiTheme.colorScheme.gray700,
+                )
+            }
+        },
     )
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(if (isEditing) NekiTheme.colorScheme.gray25 else NekiTheme.colorScheme.white),
-    ) {
-        HorizontalDivider(
-            modifier = Modifier.fillMaxWidth(),
-            thickness = 1.dp,
-            color = NekiTheme.colorScheme.gray75,
-        )
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .then(
-                    if (isPreview || isExpanded) Modifier.noRippleClickableSingle { onClickMemoText() } else Modifier,
-                )
-                .padding(
-                    start = if (isEditing) 20.dp else 12.dp,
-                    end = if (isEditing) 16.dp else 12.dp,
-                    top = if (isPreview) 8.dp else 16.dp,
-                    bottom = if (isEditing) 8.dp else 8.dp,
-                ),
-        ) {
-            if (isPreview) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Text(
-                        text = memo.ifEmpty { "메모 없음" },
-                        modifier = Modifier
-                            .weight(1f)
-                            .padding(horizontal = 8.dp),
-                        style = textFieldStyle.copy(
-                            color = if (memo.isEmpty()) NekiTheme.colorScheme.gray300
-                            else NekiTheme.colorScheme.gray700,
-                        ),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(
-                        text = "더보기",
-                        modifier = Modifier
-                            .noRippleClickableSingle { onClickMemoMore() }
-                            .padding(8.dp),
-                        style = TextStyle(
-                            fontSize = 16.sp,
-                            fontWeight = FontWeight.Medium,
-                            lineHeight = 24.sp,
-                            letterSpacing = (-0.32).sp,
-                            color = NekiTheme.colorScheme.gray200,
-                        ),
-                    )
-                }
-            } else {
-                BasicTextField(
-                    state = memoState,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .then(if (isExpanded) Modifier.padding(horizontal = 8.dp) else Modifier)
-                        .focusRequester(focusRequester)
-                        .onFocusChanged {
-                            if (it.isFocused && isExpanded) onClickMemoText()
-                        },
-                    textStyle = textFieldStyle,
-                    readOnly = isExpanded,
-                    inputTransformation = InputTransformation.maxLength(100),
-                    cursorBrush = SolidColor(
-                        if (isEditing) NekiTheme.colorScheme.gray900 else Color.Transparent,
-                    ),
-                    decorator = { innerTextField ->
-                        Box {
-                            if (memoState.text.isEmpty()) {
-                                Text(
-                                    text = if (isEditing) "자유롭게 메모를 입력해주세요. (최대 100자)" else "메모 없음",
-                                    style = textFieldStyle.copy(color = NekiTheme.colorScheme.gray300),
-                                )
-                            }
-                            innerTextField()
-                        }
-                    },
-                )
-            }
-
-            // Expanded: 메모 접기
-            if (isExpanded) {
-                Text(
-                    text = "메모 접기",
-                    modifier = Modifier
-                        .align(Alignment.End)
-                        .noRippleClickableSingle { onClickMemoFold() }
-                        .padding(start = 8.dp, end = 8.dp, bottom = 8.dp),
-                    style = TextStyle(
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Medium,
-                        lineHeight = 24.sp,
-                        letterSpacing = (-0.32).sp,
-                        color = NekiTheme.colorScheme.gray200,
-                    ),
-                )
-            }
-
-            // Editing: 카운터 + 전체지우기 + 취소/완료
-            if (isEditing) {
-                val charCount = memoState.text.length
-                val hasText = charCount > 0
-
-                Spacer(modifier = Modifier.height(8.dp))
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
-                        Text(
-                            text = "$charCount/100",
-                            style = TextStyle(
-                                fontSize = 12.sp,
-                                lineHeight = 16.sp,
-                                letterSpacing = (-0.24).sp,
-                                color = NekiTheme.colorScheme.gray300,
-                            ),
-                        )
-                        Text(
-                            text = "전체 지우기",
-                            modifier = Modifier
-                                .noRippleClickableSingle { memoState.edit { replace(0, length, "") } }
-                                .padding(8.dp),
-                            style = TextStyle(
-                                fontSize = 12.sp,
-                                fontWeight = FontWeight.Medium,
-                                lineHeight = 16.sp,
-                                letterSpacing = (-0.24).sp,
-                                color = if (hasText) NekiTheme.colorScheme.gray600
-                                else NekiTheme.colorScheme.gray200,
-                            ),
-                        )
-                    }
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = "취소",
-                            modifier = Modifier
-                                .noRippleClickableSingle { onClickMemoCancel() }
-                                .padding(vertical = 10.dp),
-                            style = TextStyle(
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.SemiBold,
-                                lineHeight = 24.sp,
-                                letterSpacing = (-0.32).sp,
-                                color = NekiTheme.colorScheme.gray800,
-                            ),
-                        )
-                        Text(
-                            text = "완료",
-                            modifier = Modifier
-                                .noRippleClickableSingle { onClickMemoDone(memoState.text.toString()) }
-                                .padding(vertical = 10.dp),
-                            style = TextStyle(
-                                fontSize = 16.sp,
-                                fontWeight = FontWeight.SemiBold,
-                                lineHeight = 24.sp,
-                                letterSpacing = (-0.32).sp,
-                                color = NekiTheme.colorScheme.primary500,
-                            ),
-                        )
-                    }
-                }
-            }
-        }
-    }
 }
 
 @ComponentPreview
@@ -368,44 +90,16 @@ private fun PhotoDetailActionBarClosedPreview() {
     NekiTheme {
         PhotoDetailActionBar(
             isFavorite = false,
-            memo = "",
-            memoMode = MemoMode.Closed,
         )
     }
 }
 
 @ComponentPreview
 @Composable
-private fun PhotoDetailActionBarPreviewPreview() {
-    NekiTheme {
-        PhotoDetailActionBar(
-            isFavorite = false,
-            memo = "재밌었던 날인데 메모가 길어서 한 줄에 다 안 들어갈 수도 있어요",
-            memoMode = MemoMode.Preview,
-        )
-    }
-}
-
-@ComponentPreview
-@Composable
-private fun PhotoDetailActionBarExpandedPreview() {
+private fun PhotoDetailActionBarMemoActivePreview() {
     NekiTheme {
         PhotoDetailActionBar(
             isFavorite = true,
-            memo = "재밌었던 날인데 메모가 길어서 한 줄에 다 안 들어갈 수도 있어요",
-            memoMode = MemoMode.Expanded,
-        )
-    }
-}
-
-@ComponentPreview
-@Composable
-private fun PhotoDetailActionBarEditingPreview() {
-    NekiTheme {
-        PhotoDetailActionBar(
-            isFavorite = true,
-            memo = "재밌었던 날",
-            memoMode = MemoMode.Editing,
         )
     }
 }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailImageItem.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailImageItem.kt
@@ -1,0 +1,105 @@
+package com.neki.android.feature.archive.impl.photo_detail.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import coil3.compose.AsyncImage
+import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
+import com.neki.android.feature.archive.impl.photo_detail.MemoMode
+
+@Composable
+internal fun PhotoDetailImageItem(
+    imageUrl: String?,
+    memo: String,
+    memoMode: MemoMode,
+    isScrollInProgress: Boolean,
+    isTapEnabled: Boolean,
+    onClickLeft: () -> Unit,
+    onClickRight: () -> Unit,
+    onClickMemoMore: () -> Unit,
+    onClickMemoText: () -> Unit,
+    onClickMemoFold: () -> Unit,
+    onClickMemoCancel: () -> Unit,
+    onClickMemoDone: (String) -> Unit,
+    onMemoTextChanged: (String) -> Unit,
+) {
+    val isMemoActive = memoMode == MemoMode.Expanded || memoMode == MemoMode.Editing
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        AsyncImage(
+            modifier = Modifier.fillMaxSize(),
+            model = imageUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Fit,
+        )
+
+        if (isTapEnabled) {
+            Row(modifier = Modifier.matchParentSize()) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .noRippleClickableSingle {
+                            if (!isScrollInProgress) onClickLeft()
+                        },
+                )
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxHeight()
+                        .noRippleClickableSingle {
+                            if (!isScrollInProgress) onClickRight()
+                        },
+                )
+            }
+        }
+
+        // dim 오버레이
+        AnimatedVisibility(
+            visible = isMemoActive,
+            enter = fadeIn(),
+            exit = fadeOut(),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color(0x80202227))
+                    .noRippleClickableSingle { onClickMemoFold() },
+            )
+        }
+
+        // 메모 텍스트 영역
+        AnimatedVisibility(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .imePadding(),
+            visible = memoMode != MemoMode.Closed,
+            enter = expandVertically(expandFrom = Alignment.Top),
+            exit = shrinkVertically(shrinkTowards = Alignment.Top),
+        ) {
+            MemoTextField(
+                memo = memo,
+                memoMode = memoMode,
+                onClickMemoMore = onClickMemoMore,
+                onClickMemoText = onClickMemoText,
+                onClickMemoFold = onClickMemoFold,
+                onClickMemoCancel = onClickMemoCancel,
+                onClickMemoDone = onClickMemoDone,
+                onMemoTextChanged = onMemoTextChanged,
+            )
+        }
+    }
+}

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailImageItem.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailImageItem.kt
@@ -8,10 +8,14 @@ import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.exclude
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -94,7 +98,12 @@ internal fun PhotoDetailImageItem(
         AnimatedVisibility(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .imePadding(),
+                .then(
+                    if (memoMode == MemoMode.Editing) Modifier.imePadding()
+                    else Modifier.windowInsetsPadding(
+                        WindowInsets.ime.exclude(WindowInsets(bottom = actionBarHeight)),
+                    ),
+                ),
             visible = memoMode != MemoMode.Closed,
             enter = expandVertically(expandFrom = Alignment.Top),
             exit = shrinkVertically(shrinkTowards = Alignment.Top),

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailImageItem.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/component/PhotoDetailImageItem.kt
@@ -11,11 +11,14 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.neki.android.core.designsystem.modifier.noRippleClickableSingle
 import com.neki.android.feature.archive.impl.photo_detail.MemoMode
@@ -25,6 +28,7 @@ internal fun PhotoDetailImageItem(
     imageUrl: String?,
     memo: String,
     memoMode: MemoMode,
+    actionBarHeight: Dp = 0.dp,
     isScrollInProgress: Boolean,
     isTapEnabled: Boolean,
     onClickLeft: () -> Unit,
@@ -37,10 +41,15 @@ internal fun PhotoDetailImageItem(
     onMemoTextChanged: (String) -> Unit,
 ) {
     val isMemoActive = memoMode == MemoMode.Expanded || memoMode == MemoMode.Editing
+    val bottomPadding = if (memoMode == MemoMode.Editing) actionBarHeight else 0.dp
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+    ) {
         AsyncImage(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(bottom = bottomPadding),
             model = imageUrl,
             contentDescription = null,
             contentScale = ContentScale.Fit,


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #168

## 📙 작업 설명
- 사진 상세 화면에 메모 기능 추가
  - 메모 속성: Photo 모델 및 API Response에 memo 필드 추가
  - 메모 편집: Preview → Expanded → Editing 모드 전환, 100자 제한, 전체 지우기
  - 메모 전송: PUT /api/photos/{photoId} API 연동, 낙관적 업데이트 + 실패 시 롤백
- 사진별 독립 메모 상태 관리 (ImmutableMap<Long, MemoMode>)
- 컴포넌트 분리
  - MemoTextField: Preview/Expanded/Editing 모드별 컴포넌트
  - PhotoDetailImageItem: 이미지 + 좌우 탭 + dim 오버레이 + 메모 영역
  - PhotoDetailActionBar: 아이콘 바 단순화
- Editing 모드 시 ActionBar 숨김 + 키보드 위에 메모 영역 배치
- dim 탭 / 취소 시 메모 초기화
- 더보기 버튼은 텍스트 overflow 시에만 표시
- 메모 수정 완료(완료 버튼) 시 이전 화면 갱신 Result 전달


## 📸 스크린샷 또는 시연 영상 (선택)

| 사진 메모 |
|-----------|
| https://github.com/user-attachments/assets/089de753-3b4f-4d9c-8e22-c3ed86973cf1 |


## 💬 추가 설명 or 리뷰 포인트 (선택)
- 리스트 조회 API(`GET /api/photos`) items에 memo 필드가 포함되어 내려오고 있습니다 (null 가능)
  - memo가 없는 사진은 null → `""` 처리
- 완료 버튼 클릭 시에만 저장되며, 뒤로가기는 저장 없이 종료됩니다