### PR TITLE
[fix] #161 앨범 상세 즐겨찾기 변경 후 Archive 갱신 누락 수정

### DIFF
--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/album_detail/AlbumDetailViewModel.kt
@@ -155,6 +155,9 @@ class AlbumDetailViewModel @AssistedInject constructor(
                 updatedFavorites.update { it + (photo.id to newFavorite) }
                 viewModelScope.launch {
                     photoRepository.updateFavorite(photo.id, newFavorite)
+                        .onSuccess {
+                            postSideEffect(AlbumDetailSideEffect.NotifyResult)
+                        }
                         .onFailure { e ->
                             Timber.e(e)
                             updatedFavorites.update { it + (photo.id to photo.isFavorite) }


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #161

## 📙 작업 설명
- 앨범 상세 화면에서 즐겨찾기 토글 성공 시 `NotifyResult`를 전송하지 않아 Archive 메인 화면이 갱신되지 않는 문제 수정
- 다른 작업(이름 변경, 사진 추가, 사진 삭제)과 동일하게 성공 시 `AlbumDetailSideEffect.NotifyResult` 추가

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [x] 기기에서 동작 확인
- [x] 기존 기능 영향 없음

## 💬 추가 설명 or 리뷰 포인트 (선택)
- 즐겨찾기 토글은 낙관적 업데이트로 처리되며, API 실패 시 롤백됨
- `NotifyResult`는 API 성공 시에만 전송 (실패 시에는 롤백만)