### PR TITLE
[fix] #190 NekiActionToast 버튼 터치 불가 버그 수정

### DIFF
--- a/core/ui/src/main/java/com/neki/android/core/ui/toast/NekiToast.kt
+++ b/core/ui/src/main/java/com/neki/android/core/ui/toast/NekiToast.kt
@@ -73,6 +73,7 @@ class NekiToast(
             WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
             PixelFormat.TRANSLUCENT,
         ).apply {
+            windowAnimations = android.R.style.Animation_Toast
             gravity = Gravity.BOTTOM or Gravity.FILL_HORIZONTAL
             y = (28 * Resources.getSystem().displayMetrics.density).toInt()
         }

--- a/core/ui/src/main/java/com/neki/android/core/ui/toast/NekiToast.kt
+++ b/core/ui/src/main/java/com/neki/android/core/ui/toast/NekiToast.kt
@@ -100,11 +100,11 @@ class NekiToast(
     }
 
     fun showActionToast(
-        @DrawableRes iconRes: Int = R.drawable.icon_checkbox_on,
         text: String,
         buttonText: String,
-        onClickActionButton: () -> Unit,
+        @DrawableRes iconRes: Int = R.drawable.icon_checkbox_on,
         duration: Int = Toast.LENGTH_SHORT,
+        onClickActionButton: () -> Unit,
     ) {
         makeToast(duration = duration) { dismiss ->
             NekiActionToast(

--- a/core/ui/src/main/java/com/neki/android/core/ui/toast/NekiToast.kt
+++ b/core/ui/src/main/java/com/neki/android/core/ui/toast/NekiToast.kt
@@ -2,7 +2,9 @@ package com.neki.android.core.ui.toast
 
 import android.content.Context
 import android.content.res.Resources
+import android.graphics.PixelFormat
 import android.view.Gravity
+import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.annotation.DrawableRes
@@ -13,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
@@ -20,17 +23,32 @@ import com.neki.android.core.designsystem.R
 import com.neki.android.core.designsystem.toast.NekiActionToast
 import com.neki.android.core.designsystem.toast.NekiToast
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class NekiToast(
     private val context: Context,
-) : Toast(context) {
-    private fun makeText(
-        duration: Int = LENGTH_SHORT,
-        toast: @Composable () -> Unit,
+) {
+    private val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+
+    private fun makeToast(
+        duration: Int = Toast.LENGTH_SHORT,
+        toast: @Composable (dismiss: () -> Unit) -> Unit,
     ) {
         val activity = context as ComponentActivity
+        var dismissJob: Job? = null
+        lateinit var composeView: ComposeView
 
-        val composeView = ComposeView(context).apply {
+        fun dismiss() {
+            dismissJob?.cancel()
+            if (composeView.isAttachedToWindow) {
+                windowManager.removeView(composeView)
+            }
+        }
+
+        composeView = ComposeView(context).apply {
             setContent {
                 NekiTheme {
                     Box(
@@ -38,7 +56,7 @@ class NekiToast(
                             .fillMaxWidth()
                             .padding(horizontal = 20.dp),
                     ) {
-                        toast()
+                        toast { dismiss() }
                     }
                 }
             }
@@ -48,25 +66,31 @@ class NekiToast(
             setViewTreeViewModelStoreOwner(activity)
         }
 
-        this.duration = duration
-        view = composeView
-        setGravity(
-            Gravity.FILL_HORIZONTAL or Gravity.BOTTOM,
-            0,
-            (28 * Resources.getSystem().displayMetrics.density).toInt(),
-        )
+        val params = WindowManager.LayoutParams(
+            WindowManager.LayoutParams.MATCH_PARENT,
+            WindowManager.LayoutParams.WRAP_CONTENT,
+            WindowManager.LayoutParams.TYPE_APPLICATION,
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
+            PixelFormat.TRANSLUCENT,
+        ).apply {
+            gravity = Gravity.BOTTOM or Gravity.FILL_HORIZONTAL
+            y = (28 * Resources.getSystem().displayMetrics.density).toInt()
+        }
 
-        show()
+        windowManager.addView(composeView, params)
+
+        dismissJob = activity.lifecycleScope.launch(Dispatchers.Main) {
+            delay(if (duration == Toast.LENGTH_SHORT) 2500L else 3500L)
+            dismiss()
+        }
     }
 
     fun showToast(
         text: String,
         @DrawableRes iconRes: Int = R.drawable.icon_checkbox_on,
-        duration: Int = LENGTH_SHORT,
+        duration: Int = Toast.LENGTH_SHORT,
     ) {
-        makeText(
-            duration = duration,
-        ) {
+        makeToast(duration = duration) {
             NekiToast(
                 iconRes = iconRes,
                 text = text,
@@ -79,16 +103,17 @@ class NekiToast(
         text: String,
         buttonText: String,
         onClickActionButton: () -> Unit,
-        duration: Int = LENGTH_SHORT,
+        duration: Int = Toast.LENGTH_SHORT,
     ) {
-        makeText(
-            duration = duration,
-        ) {
+        makeToast(duration = duration) { dismiss ->
             NekiActionToast(
                 iconRes = iconRes,
                 text = text,
                 buttonText = buttonText,
-                onClickActionButton = onClickActionButton,
+                onClickActionButton = {
+                    dismiss()
+                    onClickActionButton()
+                },
             )
         }
     }

--- a/core/ui/src/main/java/com/neki/android/core/ui/toast/NekiToast.kt
+++ b/core/ui/src/main/java/com/neki/android/core/ui/toast/NekiToast.kt
@@ -75,7 +75,7 @@ class NekiToast(
     }
 
     fun showActionToast(
-        @DrawableRes iconRes: Int,
+        @DrawableRes iconRes: Int = R.drawable.icon_checkbox_on,
         text: String,
         buttonText: String,
         onClickActionButton: () -> Unit,


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #190

## 📙 작업 설명
- `NekiToast`가 Android `Toast`를 상속하는 구조에서 `WindowManager` 기반으로 교체
- 기존 `Toast` Window는 `FLAG_NOT_TOUCHABLE`이 기본 적용되어 `ComposeView` 내 버튼 터치가 불가능했던 문제 수정(토스트 메시지 뒤의 배경이 터치되고 있었음)
- `WindowManager.LayoutParams.TYPE_APPLICATION` + `FLAG_NOT_FOCUSABLE` 조합으로 터치 이벤트 정상 전달
- `showActionToast` 버튼 클릭 시 toast가 즉시 닫히도록 `dismiss` 처리 추가

## 🧪 테스트 내역
- [x] `showToast()`, `showActionToast()` 동작 확인 완료

## 📸 스크린샷 또는 시연 영상 (선택)
|기능|미리보기|
|:--:|:--:|
| 액션 토스트 선택 |<video src="https://github.com/user-attachments/assets/4d402eab-75e3-498e-b412-b8a033ec5275" width="300" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 토스트 알림 개선

* **New Features**
  * 프로그래밍 방식의 닫기 기능 추가 — 코드 호출로 토스트를 안전하게 종료 가능
  * 액션 버튼 토스트: 버튼 클릭 시 토스트가 자동으로 닫힌 후 동작 실행

* **Improvements**
  * 표시 방식 변경으로 더 일관된 화면 오버레이 경험 제공
  * 토스트 표시 시간 기본값 조정으로 알림 노출 최적화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->