### PR TITLE
[fix] #165,#193 만료 QR 및 미지원 QR 중복 로깅 버그 수정

### DIFF
--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanContract.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanContract.kt
@@ -34,6 +34,7 @@ sealed interface QRScanIntent {
     data class ScanQRCode(val scannedUrl: String) : QRScanIntent
     data class SetViewType(val viewType: QRScanViewType) : QRScanIntent
     data class DetectImageUrl(val imageUrl: String) : QRScanIntent
+    data object WebViewError : QRScanIntent
     data object DismissShouldDownloadDialog : QRScanIntent
     data object ClickGoDownload : QRScanIntent
     data object DismissUnSupportedBrandDialog : QRScanIntent

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanScreen.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanScreen.kt
@@ -103,6 +103,7 @@ internal fun QRScanScreen(
                 PhotoWebViewContent(
                     scannedUrl = uiState.scannedUrl,
                     onDetectImageUrl = { imageUrl -> onIntent(QRScanIntent.DetectImageUrl(imageUrl)) },
+                    onPageError = { onIntent(QRScanIntent.WebViewError) },
                 )
             else {
                 LaunchedEffect(Unit) {

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
@@ -21,6 +21,7 @@ internal class QRScanViewModel @Inject constructor(
     private var webViewEnteredUrl: String? = null
     private var imageDetected: Boolean = false
     private var isDownloadRequiredBrand: Boolean = false
+    private val loggedUnsupportedUrls = mutableSetOf<String>()
 
     val store: MviIntentStore<QRScanState, QRScanIntent, QRScanSideEffect> =
         mviIntentStore(
@@ -97,8 +98,10 @@ internal class QRScanViewModel @Inject constructor(
                         }
                     }
                 } else {
-                    viewModelScope.launch {
-                        discordWebhookRepository.logUnsupportedBrandQR(scannedUrl)
+                    if (loggedUnsupportedUrls.add(scannedUrl)) {
+                        viewModelScope.launch {
+                            discordWebhookRepository.logUnsupportedBrandQR(scannedUrl)
+                        }
                     }
                     reduce { copy(isUnSupportedBrandDialogShown = true) }
                 }

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
@@ -117,6 +117,19 @@ internal class QRScanViewModel @Inject constructor(
                 postSideEffect(QRScanSideEffect.SetQRScannedResult(intent.imageUrl))
             }
 
+            QRScanIntent.WebViewError -> {
+                webViewEnteredUrl = null
+                imageDetected = false
+                isDownloadRequiredBrand = false
+                reduce {
+                    copy(
+                        viewType = QRScanViewType.QR_SCAN,
+                        scannedUrl = null,
+                    )
+                }
+                postSideEffect(QRScanSideEffect.ShowToast("만료되었거나 유효하지 않은 QR코드입니다."))
+            }
+
             QRScanIntent.DismissShouldDownloadDialog -> reduce { copy(isDownloadNeededDialogShown = false) }
             QRScanIntent.ClickGoDownload -> reduce {
                 copy(

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/component/PhotoWebViewContent.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/component/PhotoWebViewContent.kt
@@ -1,6 +1,5 @@
 package com.neki.android.feature.photo_upload.impl.qrscan.component
 
-import android.provider.SyncStateContract.Helpers.update
 import android.webkit.WebView
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
@@ -21,6 +20,7 @@ import com.neki.android.feature.photo_upload.impl.qrscan.util.PhotoWebViewClient
 internal fun PhotoWebViewContent(
     scannedUrl: String,
     onDetectImageUrl: (String) -> Unit,
+    onPageError: () -> Unit,
 ) {
     val webView = remember { mutableStateOf<WebView?>(null) }
     var isLoading by remember { mutableStateOf(true) }
@@ -42,6 +42,10 @@ internal fun PhotoWebViewContent(
 
                 webViewClient = PhotoWebViewClient(
                     onPageFinished = { isLoading = false },
+                    onPageError = {
+                        isLoading = false
+                        onPageError()
+                    },
                 ) { photoImageUrl ->
                     onDetectImageUrl(photoImageUrl)
                 }

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/util/PhotoWebViewClient.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/util/PhotoWebViewClient.kt
@@ -1,5 +1,6 @@
 package com.neki.android.feature.photo_upload.impl.qrscan.util
 
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
@@ -9,6 +10,7 @@ import timber.log.Timber
 
 class PhotoWebViewClient(
     private val onPageFinished: () -> Unit,
+    private val onPageError: () -> Unit,
     private val onImageUrlDetected: (String) -> Unit,
 ) : WebViewClient() {
 
@@ -63,5 +65,29 @@ class PhotoWebViewClient(
     override fun onPageFinished(view: WebView?, url: String?) {
         super.onPageFinished(view, url)
         onPageFinished()
+    }
+
+    override fun onReceivedError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        error: WebResourceError?,
+    ) {
+        super.onReceivedError(view, request, error)
+        if (request?.isForMainFrame == true) {
+            Timber.e("WebView main frame error: ${error?.description}")
+            onPageError()
+        }
+    }
+
+    override fun onReceivedHttpError(
+        view: WebView?,
+        request: WebResourceRequest?,
+        errorResponse: WebResourceResponse?,
+    ) {
+        super.onReceivedHttpError(view, request, errorResponse)
+        if (request?.isForMainFrame == true) {
+            Timber.e("WebView main frame HTTP error: ${errorResponse?.statusCode}")
+            onPageError()
+        }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #165
- Close #193

## 📙 작업 설명
- 미지원 브랜드 QR 스캔 시 Discord 로깅이 5~6건 중복 전송되던 문제 해결 (ML Kit BarcodeScanner 연속 콜백 원인)
  - `loggedUnsupportedUrls` Set 기반 dedupe 적용 — 같은 URL은 세션 내 1회만 로깅
- 만료/404 QR 스캔 시 흰 화면 채로 멈추던 문제 해결
  - `PhotoWebViewClient`에 `onReceivedError` / `onReceivedHttpError` 추가 (main frame 한정)
  - 신규 `QRScanIntent.WebViewError` 처리: 토스트 "만료되었거나 유효하지 않은 QR코드입니다." 안내 + 스캐너 화면 복귀

## 🧪 테스트 내역 (선택)
- [ ] 미지원 브랜드 QR 연속 스캔 시 Discord 로깅 1건만 전송
- [ ] 다른 미지원 URL 스캔 시에는 추가 1건 로깅
- [ ] 만료/404 URL QR 스캔 시 토스트 노출 + 스캐너 복귀
- [ ] 정상 지원 브랜드 QR 회귀 없음

## 📸 스크린샷 또는 시연 영상 (선택)

## 💬 추가 설명 or 리뷰 포인트 (선택)
- WebView HTTP 에러는 서브리소스(이미지/광고) 404에도 발화하므로 `request.isForMainFrame == true` 가드 필수