### PR TITLE
[fix] #200 브랜드 마커 선택 시 줌 레벨 강제 초기화 버그 수정

### DIFF
--- a/build-logic/src/main/java/com/neki/android/buildlogic/const/BuildConst.kt
+++ b/build-logic/src/main/java/com/neki/android/buildlogic/const/BuildConst.kt
@@ -5,7 +5,7 @@ import org.gradle.api.JavaVersion
 object BuildConst {
     const val APPLICATION_ID = "com.neki.android"
 
-    const val VERSION_CODE = 16
+    const val VERSION_CODE = 17
     const val VERSION_NAME = "1.2.0"
 
     const val MIN_SDK = 29

--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapContract.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapContract.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.graphics.ImageBitmap
 import com.neki.android.core.model.Brand
 import com.neki.android.core.model.PhotoBooth
 import com.neki.android.feature.map.impl.const.DirectionApp
+import com.neki.android.feature.map.impl.const.MapConst
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentListOf
@@ -63,6 +64,7 @@ sealed interface MapEffect {
     data class MoveCameraToPosition(
         val locLatLng: LocLatLng,
         val isRequiredLoadPhotoBooths: Boolean = false,
+        val zoomLevel: Double = MapConst.DEFAULT_ZOOM_LEVEL,
     ) : MapEffect
     data class ZoomToClusterBounds(
         val southWest: LocLatLng,

--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapScreen.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapScreen.kt
@@ -141,7 +141,7 @@ fun MapRoute(
                     cameraPositionState.animate(
                         update = CameraUpdate.scrollAndZoomTo(
                             LatLng(sideEffect.locLatLng.latitude, sideEffect.locLatLng.longitude),
-                            MapConst.DEFAULT_ZOOM_LEVEL,
+                            sideEffect.zoomLevel,
                         ),
                         animation = CameraAnimation.Easing,
                         durationMs = MapConst.DEFAULT_CAMERA_ANIMATION_DURATIONS_MS,

--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/const/MapConst.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/const/MapConst.kt
@@ -7,6 +7,7 @@ internal object MapConst {
 
     // 기본 줌 레벨
     internal const val DEFAULT_ZOOM_LEVEL = 14.0
+    internal const val MARKER_SELECTED_ZOOM_LEVEL = 18.0
     internal const val MIN_ZOOM_LEVEL = 12.0
     internal const val MAX_ZOOM_LEVEL = 20.0
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #200

## 📙 작업 설명
- `MoveCameraToPosition` SideEffect에 `zoomLevel: Double = MapConst.DEFAULT_ZOOM_LEVEL` 파라미터 추가
- `MapConst`에 `MARKER_SELECTED_ZOOM_LEVEL = 18.0` 상수 추가
- 브랜드 마커 클릭 시 `MARKER_SELECTED_ZOOM_LEVEL(18.0)`을 명시적으로 전달하도록 수정
- `MapScreen`에서 `sideEffect.zoomLevel`을 직접 사용하도록 변경

## 🧪 테스트 내역
- 없음

## 📸 스크린샷 또는 시연 영상
- 없음

## 💬 추가 설명 or 리뷰 포인트
- 기존에는 `DEFAULT_ZOOM_LEVEL`이 17.0이어서 체감상 문제가 없었으나, #192에서 14.0으로 낮아지면서 마커 선택 시 줌이 멀어지는 현상이 드러남
- 마커 클릭 외 케이스(현위치 이동 등)는 기본값(`DEFAULT_ZOOM_LEVEL = 14.0`) 그대로 유지

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* 지도 카메라 줌 동작 최적화로 더 정확한 위치 표시
* 마커 선택 시 향상된 줌 레벨 적용  
* 위치 권한 관리 및 권한 요청 흐름 개선
* 지도 제스처 및 카메라 추적 강화
* 클러스터 마커 및 포토부스 카드 상호작용 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->