### PR TITLE
[fix] #202 브랜드 마커 선택 시 줌 레벨 MapViewModel에 적용

### DIFF
--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
@@ -258,7 +258,8 @@ class MapViewModel @Inject constructor(
         postSideEffect(
             MapEffect.MoveCameraToPosition(
                 locLatLng = LocLatLng(photoBooth.latitude, photoBooth.longitude),
-                zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL)
+                zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL,
+            ),
         )
     }
 

--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
@@ -253,7 +253,7 @@ class MapViewModel @Inject constructor(
                 mapMarkers = updatedMarkers.toImmutableList(),
             )
         }
-        postSideEffect(MapEffect.MoveCameraToPosition(LocLatLng(photoBooth.latitude, photoBooth.longitude)))
+        postSideEffect(MapEffect.MoveCameraToPosition(LocLatLng(photoBooth.latitude, photoBooth.longitude), zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL))
     }
 
     private fun handleClickDirectionItem(
@@ -327,7 +327,7 @@ class MapViewModel @Inject constructor(
         locLatLng: LocLatLng,
         postSideEffect: (MapEffect) -> Unit,
     ) {
-        postSideEffect(MapEffect.MoveCameraToPosition(locLatLng))
+        postSideEffect(MapEffect.MoveCameraToPosition(locLatLng, zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL))
     }
 
     private fun fetchInitialData(reduce: (MapState.() -> MapState) -> Unit) {

--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
@@ -320,7 +320,7 @@ class MapViewModel @Inject constructor(
                 mapMarkers = updatedMarkers.toImmutableList(),
             )
         }
-        postSideEffect(MapEffect.MoveCameraToPosition(locLatLng))
+        postSideEffect(MapEffect.MoveCameraToPosition(locLatLng, zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL))
     }
 
     private fun handleClickPhotoBoothCard(

--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
@@ -138,7 +138,7 @@ class MapViewModel @Inject constructor(
                     // 위치 조회 실패 시 강남역으로 카메라 이동
                     postSideEffect(
                         MapEffect.MoveCameraToPosition(
-                            LocLatLng(MapConst.DEFAULT_LATITUDE, MapConst.DEFAULT_LONGITUDE),
+                            locLatLng = LocLatLng(MapConst.DEFAULT_LATITUDE, MapConst.DEFAULT_LONGITUDE),
                             isRequiredLoadPhotoBooths = true,
                             zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL,
                         ),
@@ -183,7 +183,7 @@ class MapViewModel @Inject constructor(
             reduce { copy(isCameraOnCurrentLocation = true, isVisibleRefreshButton = false) }
             postSideEffect(
                 MapEffect.MoveCameraToPosition(
-                    LocLatLng(state.currentLocLatLng.latitude, state.currentLocLatLng.longitude),
+                    locLatLng = LocLatLng(state.currentLocLatLng.latitude, state.currentLocLatLng.longitude),
                     isRequiredLoadPhotoBooths = true,
                     zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL,
                 ),

--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
@@ -131,7 +131,13 @@ class MapViewModel @Inject constructor(
             LocationHelper.getCurrentLocation(context)
                 .onSuccess { location ->
                     reduce { copy(isCameraOnCurrentLocation = true, isVisibleRefreshButton = false) }
-                    postSideEffect(MapEffect.MoveCameraToPosition(location, isRequiredLoadPhotoBooths = true, zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL))
+                    postSideEffect(
+                        MapEffect.MoveCameraToPosition(
+                            locLatLng = location,
+                            isRequiredLoadPhotoBooths = true,
+                            zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL,
+                        ),
+                    )
                 }
                 .onFailure { e ->
                     Timber.e(e)

--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
@@ -131,14 +131,14 @@ class MapViewModel @Inject constructor(
             LocationHelper.getCurrentLocation(context)
                 .onSuccess { location ->
                     reduce { copy(isCameraOnCurrentLocation = true, isVisibleRefreshButton = false) }
-                    postSideEffect(MapEffect.MoveCameraToPosition(locLatLng = location, isRequiredLoadPhotoBooths = true))
+                    postSideEffect(MapEffect.MoveCameraToPosition(location, isRequiredLoadPhotoBooths = true))
                 }
                 .onFailure { e ->
                     Timber.e(e)
                     // 위치 조회 실패 시 강남역으로 카메라 이동
                     postSideEffect(
                         MapEffect.MoveCameraToPosition(
-                            locLatLng = LocLatLng(MapConst.DEFAULT_LATITUDE, MapConst.DEFAULT_LONGITUDE),
+                            LocLatLng(MapConst.DEFAULT_LATITUDE, MapConst.DEFAULT_LONGITUDE),
                             isRequiredLoadPhotoBooths = true,
                         ),
                     )
@@ -182,7 +182,7 @@ class MapViewModel @Inject constructor(
             reduce { copy(isCameraOnCurrentLocation = true, isVisibleRefreshButton = false) }
             postSideEffect(
                 MapEffect.MoveCameraToPosition(
-                    locLatLng = LocLatLng(state.currentLocLatLng.latitude, state.currentLocLatLng.longitude),
+                    LocLatLng(state.currentLocLatLng.latitude, state.currentLocLatLng.longitude),
                     isRequiredLoadPhotoBooths = true,
                 ),
             )

--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
@@ -131,7 +131,7 @@ class MapViewModel @Inject constructor(
             LocationHelper.getCurrentLocation(context)
                 .onSuccess { location ->
                     reduce { copy(isCameraOnCurrentLocation = true, isVisibleRefreshButton = false) }
-                    postSideEffect(MapEffect.MoveCameraToPosition(location, isRequiredLoadPhotoBooths = true))
+                    postSideEffect(MapEffect.MoveCameraToPosition(location, isRequiredLoadPhotoBooths = true, zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL))
                 }
                 .onFailure { e ->
                     Timber.e(e)
@@ -140,6 +140,7 @@ class MapViewModel @Inject constructor(
                         MapEffect.MoveCameraToPosition(
                             LocLatLng(MapConst.DEFAULT_LATITUDE, MapConst.DEFAULT_LONGITUDE),
                             isRequiredLoadPhotoBooths = true,
+                            zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL,
                         ),
                     )
                 }
@@ -184,6 +185,7 @@ class MapViewModel @Inject constructor(
                 MapEffect.MoveCameraToPosition(
                     LocLatLng(state.currentLocLatLng.latitude, state.currentLocLatLng.longitude),
                     isRequiredLoadPhotoBooths = true,
+                    zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL,
                 ),
             )
         }

--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
@@ -237,6 +237,7 @@ class MapViewModel @Inject constructor(
                 brandName = photoBooth.brandName,
             ),
         )
+
         reduce {
             val isAlreadyInMarkers = mapMarkers.any {
                 it.latitude == photoBooth.latitude && it.longitude == photoBooth.longitude
@@ -253,7 +254,12 @@ class MapViewModel @Inject constructor(
                 mapMarkers = updatedMarkers.toImmutableList(),
             )
         }
-        postSideEffect(MapEffect.MoveCameraToPosition(locLatLng = LocLatLng(photoBooth.latitude, photoBooth.longitude), zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL))
+
+        postSideEffect(
+            MapEffect.MoveCameraToPosition(
+                locLatLng = LocLatLng(photoBooth.latitude, photoBooth.longitude),
+                zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL)
+        )
     }
 
     private fun handleClickDirectionItem(

--- a/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
+++ b/feature/map/impl/src/main/java/com/neki/android/feature/map/impl/MapViewModel.kt
@@ -131,14 +131,14 @@ class MapViewModel @Inject constructor(
             LocationHelper.getCurrentLocation(context)
                 .onSuccess { location ->
                     reduce { copy(isCameraOnCurrentLocation = true, isVisibleRefreshButton = false) }
-                    postSideEffect(MapEffect.MoveCameraToPosition(location, isRequiredLoadPhotoBooths = true))
+                    postSideEffect(MapEffect.MoveCameraToPosition(locLatLng = location, isRequiredLoadPhotoBooths = true))
                 }
                 .onFailure { e ->
                     Timber.e(e)
                     // 위치 조회 실패 시 강남역으로 카메라 이동
                     postSideEffect(
                         MapEffect.MoveCameraToPosition(
-                            LocLatLng(MapConst.DEFAULT_LATITUDE, MapConst.DEFAULT_LONGITUDE),
+                            locLatLng = LocLatLng(MapConst.DEFAULT_LATITUDE, MapConst.DEFAULT_LONGITUDE),
                             isRequiredLoadPhotoBooths = true,
                         ),
                     )
@@ -182,7 +182,7 @@ class MapViewModel @Inject constructor(
             reduce { copy(isCameraOnCurrentLocation = true, isVisibleRefreshButton = false) }
             postSideEffect(
                 MapEffect.MoveCameraToPosition(
-                    LocLatLng(state.currentLocLatLng.latitude, state.currentLocLatLng.longitude),
+                    locLatLng = LocLatLng(state.currentLocLatLng.latitude, state.currentLocLatLng.longitude),
                     isRequiredLoadPhotoBooths = true,
                 ),
             )
@@ -253,7 +253,7 @@ class MapViewModel @Inject constructor(
                 mapMarkers = updatedMarkers.toImmutableList(),
             )
         }
-        postSideEffect(MapEffect.MoveCameraToPosition(LocLatLng(photoBooth.latitude, photoBooth.longitude), zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL))
+        postSideEffect(MapEffect.MoveCameraToPosition(locLatLng = LocLatLng(photoBooth.latitude, photoBooth.longitude), zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL))
     }
 
     private fun handleClickDirectionItem(
@@ -320,14 +320,14 @@ class MapViewModel @Inject constructor(
                 mapMarkers = updatedMarkers.toImmutableList(),
             )
         }
-        postSideEffect(MapEffect.MoveCameraToPosition(locLatLng, zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL))
+        postSideEffect(MapEffect.MoveCameraToPosition(locLatLng = locLatLng, zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL))
     }
 
     private fun handleClickPhotoBoothCard(
         locLatLng: LocLatLng,
         postSideEffect: (MapEffect) -> Unit,
     ) {
-        postSideEffect(MapEffect.MoveCameraToPosition(locLatLng, zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL))
+        postSideEffect(MapEffect.MoveCameraToPosition(locLatLng = locLatLng, zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL))
     }
 
     private fun fetchInitialData(reduce: (MapState.() -> MapState) -> Unit) {


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #202

## 📙 작업 설명
- `MapViewModel.handleClickPhotoBoothMarker`의 `postSideEffect` 호출 시 `zoomLevel = MapConst.MARKER_SELECTED_ZOOM_LEVEL(18.0)` 추가
- #200(PR #201)에서 `MoveCameraToPosition`에 `zoomLevel` 파라미터를 추가했으나 `MapViewModel` 적용이 누락된 부분 수정

## 🧪 테스트 내역
- [x] "포토부스 마커" 선택
- [x] "포토부스 상세 카드" 선택
- [x] "현위치" 버튼 선택
- [x] 가까운 "네컷 사진 브랜드" 선택

## 📸 스크린샷 또는 시연 영상
|기능|미리보기|
|:--:|:--:|
| 카메라 이동 |<video src="https://github.com/user-attachments/assets/5e6f92f4-bad0-44d6-af67-3de5201922f6" width="300" />|

## 💬 추가 설명 or 리뷰 포인트
- 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 포토부스 마커 선택 시 지도가 해당 위치로 카메라를 이동하고, 최적화된 줌 레벨을 자동으로 적용하여 더 나은 보기 환경을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->