### PR TITLE
[feat] #206 QR 지원 브랜드 추가 (포토시그니처, 모노맨션)

### DIFF
--- a/feature/photo-upload/impl/build.gradle.kts
+++ b/feature/photo-upload/impl/build.gradle.kts
@@ -30,9 +30,13 @@ android {
         buildConfigField("String", "LIFE_FOUR_CUT_IMAGE_URL", properties["LIFE_FOUR_CUT_IMAGE_URL"].toString())
         buildConfigField("String", "LIFE_FOUR_CUT_IMAGE_URL_MIME_TYPE", properties["LIFE_FOUR_CUT_IMAGE_URL_MIME_TYPE"].toString())
 
-        buildConfigField("String", "PHOTO_SIGNATURE_URL", properties["PHOTO_SIGNATURE_URL"].toString())
-        buildConfigField("String", "PHOTO_SIGNATURE_IMAGE_URL", properties["PHOTO_SIGNATURE_IMAGE_URL"].toString())
-        buildConfigField("String", "PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE", properties["PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE"].toString())
+        buildConfigField("String", "PHOTO_SIGNATURE_URL_1", properties["PHOTO_SIGNATURE_URL_1"].toString())
+        buildConfigField("String", "PHOTO_SIGNATURE_IMAGE_URL_1", properties["PHOTO_SIGNATURE_IMAGE_URL_1"].toString())
+        buildConfigField("String", "PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE_1", properties["PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE_1"].toString())
+
+        buildConfigField("String", "PHOTO_SIGNATURE_URL_2", properties["PHOTO_SIGNATURE_URL_2"].toString())
+        buildConfigField("String", "PHOTO_SIGNATURE_IMAGE_URL_2", properties["PHOTO_SIGNATURE_IMAGE_URL_2"].toString())
+        buildConfigField("String", "PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE_2", properties["PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE_2"].toString())
 
         buildConfigField("String", "HARU_FILM_URL", properties["HARU_FILM_URL"].toString())
         buildConfigField("String", "HARU_FILM_IMAGE_URL", properties["HARU_FILM_IMAGE_URL"].toString())

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/QRScanViewModel.kt
@@ -157,7 +157,8 @@ internal class QRScanViewModel @Inject constructor(
     private fun isSupportedBrand(url: String): Boolean {
         return url.contains(BuildConfig.PHOTOISM_URL) ||
             url.contains(BuildConfig.LIFE_FOUR_CUT_URL) ||
-            url.contains(BuildConfig.PHOTO_SIGNATURE_URL) ||
+            url.contains(BuildConfig.PHOTO_SIGNATURE_URL_1) ||
+            url.contains(BuildConfig.PHOTO_SIGNATURE_URL_2) ||
             url.contains(BuildConfig.HARU_FILM_URL) ||
             url.contains(BuildConfig.PHOTO_GRAY_URL) ||
             url.contains(BuildConfig.MONO_MANSION_URL)
@@ -166,6 +167,7 @@ internal class QRScanViewModel @Inject constructor(
     private fun isShouldFirstDownloadBrand(url: String): Boolean {
         return url.contains(BuildConfig.MONO_MANSION_URL) ||
             url.contains(BuildConfig.PHOTO_GRAY_URL) ||
-            url.contains(BuildConfig.PHOTO_SIGNATURE_URL)
+            url.contains(BuildConfig.PHOTO_SIGNATURE_URL_1) ||
+            url.contains(BuildConfig.PHOTO_SIGNATURE_URL_2)
     }
 }

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/util/PhotoWebViewClient.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/util/PhotoWebViewClient.kt
@@ -35,7 +35,13 @@ class PhotoWebViewClient(
             }
 
             // 포토시그니처
-            url.contains(BuildConfig.PHOTO_SIGNATURE_IMAGE_URL) && url.endsWith(BuildConfig.PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE) -> {
+            url.contains(BuildConfig.PHOTO_SIGNATURE_IMAGE_URL_1) && url.endsWith(BuildConfig.PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE_1) -> {
+                Timber.d("포토시그니처 이미지")
+                onImageUrlDetected(url)
+            }
+
+            // 포토시그니처
+            url.contains(BuildConfig.PHOTO_SIGNATURE_IMAGE_URL_2) && url.endsWith(BuildConfig.PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE_2) -> {
                 Timber.d("포토시그니처 이미지")
                 onImageUrlDetected(url)
             }

--- a/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/util/PhotoWebViewClient.kt
+++ b/feature/photo-upload/impl/src/main/java/com/neki/android/feature/photo_upload/impl/qrscan/util/PhotoWebViewClient.kt
@@ -59,7 +59,8 @@ class PhotoWebViewClient(
             }
 
             // 모노맨션
-            url.contains(BuildConfig.MONO_MANSION_IMAGE_URL) && url.endsWith(BuildConfig.MONO_MANSION_IMAGE_URL_MIME_TYPE) -> {
+            url.contains(BuildConfig.MONO_MANSION_IMAGE_URL, ignoreCase = true) &&
+                url.endsWith(BuildConfig.MONO_MANSION_IMAGE_URL_MIME_TYPE, ignoreCase = true) -> {
                 Timber.d("모노맨션 이미지")
                 onImageUrlDetected(url)
             }


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #206

## 📙 작업 설명
- 포토시그니처 QR 신규 도메인 지원 추가
  - 기존 `PHOTO_SIGNATURE_URL` 셋을 `_1` suffix로 리네임 (`photoqr3.kr` 유지)
  - 신규 viewer 도메인(`photosignature-viewer.web.app`) + 자산 CDN(`photosignature-asset-cdn.photosignature.workers.dev/sessions/`) → `_2` 셋으로 추가
  - `final.jpg` 매칭으로 분할샷(`photo_1.jpg`~`photo_8.jpg`) 제외
- 모노맨션 QR 이미지 매칭 대소문자 무시 적용
  - `COMPLETE.jpg` / `complete.jpg` 대소문자 변형 모두 매칭

## 📸 스크린샷 또는 시연 영상 (선택)

## 💬 추가 설명 or 리뷰 포인트 (선택)
- local.properties 신규/리네임 키 셋팅 필요:
  - `PHOTO_SIGNATURE_URL_1`, `PHOTO_SIGNATURE_IMAGE_URL_1`, `PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE_1` (기존 키 리네임)
  - `PHOTO_SIGNATURE_URL_2`, `PHOTO_SIGNATURE_IMAGE_URL_2`, `PHOTO_SIGNATURE_IMAGE_URL_MIME_TYPE_2` (신규)
  - `MONO_MANSION_IMAGE_URL` = `ncloudstorage.com`, `MONO_MANSION_IMAGE_URL_MIME_TYPE` = `COMPLETE.jpg`
- 모노맨션은 페이지가 `href` 다운로드 링크 구조라 WebView 자동 렌더 시 이미지 요청이 안 날 가능성 있음 → 실 QR로 동작 검증 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 다중 사진 서명 설정 지원으로 사진 업로드 기능의 유연성 강화
  * URL 매칭 시 대소문자 구분을 제거하여 안정성 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/YAPP-Github/27th-App-Team-2-Android/pull/207)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->