### PR TITLE
[feat] #209 마케팅 수신동의 팝업 및 Permission 화면 개선

### DIFF
--- a/core/common/src/main/java/com/neki/android/core/common/const/TermConst.kt
+++ b/core/common/src/main/java/com/neki/android/core/common/const/TermConst.kt
@@ -1,0 +1,6 @@
+package com.neki.android.core.common.const
+
+object TermConst {
+    const val MARKETING_TERM_ID = 4L
+    const val MARKETING_POPUP_INTERVAL_MS = 7L * 24 * 60 * 60 * 1000
+}

--- a/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/TermRepository.kt
+++ b/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/TermRepository.kt
@@ -5,4 +5,5 @@ import com.neki.android.core.model.Term
 interface TermRepository {
     suspend fun getTerms(): Result<List<Term>>
     suspend fun agreeTerms(termIds: List<Long>): Result<Unit>
+    suspend fun updateTermAgreement(termId: Long, agreed: Boolean): Result<Unit>
 }

--- a/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/UserRepository.kt
+++ b/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/UserRepository.kt
@@ -10,6 +10,9 @@ interface UserRepository {
     suspend fun setInfoToolTipShown()
     val hasShownQRInfoToolTip: Flow<Boolean>
     suspend fun setQRInfoToolTipShown()
+    val lastArchiveMarketingPopupTimestamp: Flow<Long>
+    val archiveMarketingPopupShownCount: Flow<Int>
+    suspend fun recordMarketingPopupShown()
 
     suspend fun getUserInfo(): Result<UserInfo>
     suspend fun updateUserInfo(nickname: String): Result<Unit>

--- a/core/data/src/main/java/com/neki/android/core/data/remote/model/response/UserInfoResponse.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/model/response/UserInfoResponse.kt
@@ -12,6 +12,8 @@ data class UserInfoResponse(
     @SerialName("profileImageUrl") val profileImageUrl: String = "",
     @SerialName("providerType") val providerType: String = "",
     @SerialName("agreeTerms") val agreeTerms: Boolean = false,
+    @SerialName("marketingTerm") val marketingTerm: Boolean = false,
+    @SerialName("pushAgreed") val pushAgreed: Boolean = false,
 ) {
     fun toModel() = UserInfo(
         id = userId,
@@ -19,5 +21,6 @@ data class UserInfoResponse(
         profileImageUrl = profileImageUrl,
         loginType = providerType,
         isRequiredTermsAgreed = agreeTerms,
+        isMarketingTermAgreed = marketingTerm,
     )
 }

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/TermRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/TermRepositoryImpl.kt
@@ -22,4 +22,11 @@ class TermRepositoryImpl @Inject constructor(
         )
         termService.agreeTerms(request)
     }
+
+    override suspend fun updateTermAgreement(termId: Long, agreed: Boolean): Result<Unit> = runSuspendCatching {
+        val request = TermAgreementsRequest(
+            agreements = listOf(TermAgreementsRequest.Agreement(termId = termId, agreed = agreed)),
+        )
+        termService.agreeTerms(request)
+    }
 }

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/UserRepositoryImpl.kt
@@ -3,6 +3,8 @@ package com.neki.android.core.data.repository.impl
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.edit
 import com.neki.android.core.data.local.di.UserDataStore
 import com.neki.android.core.data.remote.api.UserService
@@ -52,6 +54,19 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
+    override val lastArchiveMarketingPopupTimestamp: Flow<Long> =
+        dataStore.data.map { it[LAST_ARCHIVE_MARKETING_POPUP_TIMESTAMP] ?: 0L }
+
+    override val archiveMarketingPopupShownCount: Flow<Int> =
+        dataStore.data.map { it[ARCHIVE_MARKETING_POPUP_SHOWN_COUNT] ?: 0 }
+
+    override suspend fun recordMarketingPopupShown() {
+        dataStore.edit {
+            it[LAST_ARCHIVE_MARKETING_POPUP_TIMESTAMP] = System.currentTimeMillis()
+            it[ARCHIVE_MARKETING_POPUP_SHOWN_COUNT] = (it[ARCHIVE_MARKETING_POPUP_SHOWN_COUNT] ?: 0) + 1
+        }
+    }
+
     override suspend fun getUserInfo(): Result<UserInfo> = runSuspendCatching {
         userService.getUserInfo().data.toModel()
     }
@@ -68,5 +83,8 @@ class UserRepositoryImpl @Inject constructor(
         private val HAS_VISITED_RANDOM_POSE = booleanPreferencesKey("is_first_visit_random_pose")
         private val HAS_SHOWN_INFO_TOOLTIP = booleanPreferencesKey("is_first_expand_bottom_sheet")
         private val HAS_SHOWN_QR_INFO_TOOLTIP = booleanPreferencesKey("is_first_visit_archive")
+        private val LAST_ARCHIVE_MARKETING_POPUP_TIMESTAMP =
+            longPreferencesKey("last_archive_marketing_popup_timestamp")
+        private val ARCHIVE_MARKETING_POPUP_SHOWN_COUNT = intPreferencesKey("archive_marketing_popup_shown_count")
     }
 }

--- a/core/designsystem/src/main/java/com/neki/android/core/designsystem/dialog/DoubleButtonSubContentDialog.kt
+++ b/core/designsystem/src/main/java/com/neki/android/core/designsystem/dialog/DoubleButtonSubContentDialog.kt
@@ -1,0 +1,143 @@
+package com.neki.android.core.designsystem.dialog
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.neki.android.core.designsystem.ComponentPreview
+import com.neki.android.core.designsystem.R
+import com.neki.android.core.designsystem.button.CTAButtonGray
+import com.neki.android.core.designsystem.button.CTAButtonPrimary
+import com.neki.android.core.designsystem.ui.theme.NekiTheme
+
+@Composable
+fun DoubleButtonSubContentDialog(
+    title: String,
+    content: String,
+    grayButtonText: String,
+    primaryButtonText: String,
+    onDismissRequest: () -> Unit,
+    onClickPrimaryButton: () -> Unit,
+    onClickGrayButton: () -> Unit,
+    subContent: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    properties: DialogProperties = DialogProperties(
+        usePlatformDefaultWidth = false,
+    ),
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = properties,
+    ) {
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .widthIn(max = 400.dp)
+                .clip(RoundedCornerShape(20.dp))
+                .background(NekiTheme.colorScheme.white)
+                .padding(top = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Image(
+                modifier = Modifier.size(64.dp),
+                painter = painterResource(R.drawable.image_dialog_alert),
+                contentDescription = null,
+            )
+            Column(
+                modifier = Modifier.padding(horizontal = 24.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = title,
+                    style = NekiTheme.typography.title24Bold,
+                    color = NekiTheme.colorScheme.gray900,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = content,
+                    style = NekiTheme.typography.body14Regular,
+                    color = NekiTheme.colorScheme.gray500,
+                    textAlign = TextAlign.Center,
+                )
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp)
+                    .background(
+                        color = NekiTheme.colorScheme.gray50,
+                        shape = RoundedCornerShape(12.dp),
+                    )
+                    .border(
+                        width = 1.dp,
+                        color = NekiTheme.colorScheme.gray100,
+                        shape = RoundedCornerShape(12.dp),
+                    )
+                    .padding(16.dp),
+            ) {
+                subContent()
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                CTAButtonGray(
+                    text = grayButtonText,
+                    onClick = onClickGrayButton,
+                    modifier = Modifier.weight(1f),
+                )
+                CTAButtonPrimary(
+                    text = primaryButtonText,
+                    onClick = onClickPrimaryButton,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun DoubleButtonSubContentDialogPreview() {
+    NekiTheme {
+        DoubleButtonSubContentDialog(
+            title = "메인 텍스트가 들어가는 곳",
+            content = "보조 설명 텍스트가 들어가는 공간입니다",
+            grayButtonText = "텍스트",
+            primaryButtonText = "텍스트",
+            onDismissRequest = {},
+            onClickPrimaryButton = {},
+            onClickGrayButton = {},
+            subContent = {
+                Text(
+                    text = "서브 콘텐츠 영역입니다.",
+                    style = NekiTheme.typography.body14Regular,
+                    color = NekiTheme.colorScheme.gray500,
+                )
+            },
+        )
+    }
+}

--- a/core/designsystem/src/main/java/com/neki/android/core/designsystem/dialog/DoubleButtonSubContentDialog.kt
+++ b/core/designsystem/src/main/java/com/neki/android/core/designsystem/dialog/DoubleButtonSubContentDialog.kt
@@ -95,7 +95,7 @@ fun DoubleButtonSubContentDialog(
                         shape = RoundedCornerShape(12.dp),
                     )
                     .padding(16.dp),
-                contentAlignment = Alignment.Center
+                contentAlignment = Alignment.Center,
             ) {
                 subContent()
             }

--- a/core/designsystem/src/main/java/com/neki/android/core/designsystem/dialog/DoubleButtonSubContentDialog.kt
+++ b/core/designsystem/src/main/java/com/neki/android/core/designsystem/dialog/DoubleButtonSubContentDialog.kt
@@ -84,7 +84,7 @@ fun DoubleButtonSubContentDialog(
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 24.dp)
+                    .padding(horizontal = 12.dp, vertical = 6.dp)
                     .background(
                         color = NekiTheme.colorScheme.gray50,
                         shape = RoundedCornerShape(12.dp),
@@ -95,13 +95,14 @@ fun DoubleButtonSubContentDialog(
                         shape = RoundedCornerShape(12.dp),
                     )
                     .padding(16.dp),
+                contentAlignment = Alignment.Center
             ) {
                 subContent()
             }
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(12.dp),
+                    .padding(start = 12.dp, end = 12.dp, bottom = 12.dp),
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 CTAButtonGray(

--- a/core/designsystem/src/main/java/com/neki/android/core/designsystem/toggle/NekiToggle.kt
+++ b/core/designsystem/src/main/java/com/neki/android/core/designsystem/toggle/NekiToggle.kt
@@ -20,8 +20,8 @@ import com.neki.android.core.designsystem.ui.theme.NekiTheme
 @Composable
 fun NekiToggle(
     checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    onCheckedChange: (Boolean) -> Unit = {},
 ) {
     val thumbOffset by animateDpAsState(
         targetValue = if (checked) 26.dp else 2.dp,
@@ -51,7 +51,7 @@ fun NekiToggle(
 @Composable
 private fun NekiToggleOnPreview() {
     NekiTheme {
-        NekiToggle(checked = true, onCheckedChange = {})
+        NekiToggle(checked = true)
     }
 }
 
@@ -59,6 +59,6 @@ private fun NekiToggleOnPreview() {
 @Composable
 private fun NekiToggleOffPreview() {
     NekiTheme {
-        NekiToggle(checked = false, onCheckedChange = {})
+        NekiToggle(checked = false)
     }
 }

--- a/core/designsystem/src/main/java/com/neki/android/core/designsystem/toggle/NekiToggle.kt
+++ b/core/designsystem/src/main/java/com/neki/android/core/designsystem/toggle/NekiToggle.kt
@@ -1,0 +1,64 @@
+package com.neki.android.core.designsystem.toggle
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+import com.neki.android.core.designsystem.ComponentPreview
+import com.neki.android.core.designsystem.ui.theme.NekiTheme
+
+@Composable
+fun NekiToggle(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val thumbOffset by animateDpAsState(
+        targetValue = if (checked) 26.dp else 2.dp,
+        animationSpec = tween(durationMillis = 200),
+        label = "toggleThumb",
+    )
+
+    Box(
+        modifier = modifier
+            .size(width = 52.dp, height = 28.dp)
+            .clip(CircleShape)
+            .background(if (checked) NekiTheme.colorScheme.primary300 else NekiTheme.colorScheme.gray100)
+            .clickable { onCheckedChange(!checked) },
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Box(
+            modifier = Modifier
+                .offset(x = thumbOffset)
+                .size(24.dp)
+                .clip(CircleShape)
+                .background(NekiTheme.colorScheme.white),
+        )
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun NekiToggleOnPreview() {
+    NekiTheme {
+        NekiToggle(checked = true, onCheckedChange = {})
+    }
+}
+
+@ComponentPreview
+@Composable
+private fun NekiToggleOffPreview() {
+    NekiTheme {
+        NekiToggle(checked = false, onCheckedChange = {})
+    }
+}

--- a/core/model/src/main/java/com/neki/android/core/model/UserInfo.kt
+++ b/core/model/src/main/java/com/neki/android/core/model/UserInfo.kt
@@ -9,4 +9,5 @@ data class UserInfo(
     val profileImageUrl: String = "",
     val loginType: String = "",
     val isRequiredTermsAgreed: Boolean = false,
+    val isMarketingTermAgreed: Boolean = false,
 )

--- a/core/ui/src/main/java/com/neki/android/core/ui/toast/NekiToast.kt
+++ b/core/ui/src/main/java/com/neki/android/core/ui/toast/NekiToast.kt
@@ -32,19 +32,34 @@ class NekiToast(
     private val context: Context,
 ) {
     private val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    private var currentComposeView: ComposeView? = null
+    private var currentDismissJob: Job? = null
+
+    private fun dismissCurrent() {
+        currentDismissJob?.cancel()
+        currentComposeView?.let {
+            if (it.isAttachedToWindow) windowManager.removeView(it)
+        }
+        currentComposeView = null
+        currentDismissJob = null
+    }
 
     private fun makeToast(
         duration: Int = Toast.LENGTH_SHORT,
         toast: @Composable (dismiss: () -> Unit) -> Unit,
     ) {
         val activity = context as ComponentActivity
-        var dismissJob: Job? = null
+        dismissCurrent()
         lateinit var composeView: ComposeView
 
         fun dismiss() {
-            dismissJob?.cancel()
+            currentDismissJob?.cancel()
             if (composeView.isAttachedToWindow) {
                 windowManager.removeView(composeView)
+            }
+            if (currentComposeView === composeView) {
+                currentComposeView = null
+                currentDismissJob = null
             }
         }
 
@@ -78,9 +93,10 @@ class NekiToast(
             y = (28 * Resources.getSystem().displayMetrics.density).toInt()
         }
 
+        currentComposeView = composeView
         windowManager.addView(composeView, params)
 
-        dismissJob = activity.lifecycleScope.launch(Dispatchers.Main) {
+        currentDismissJob = activity.lifecycleScope.launch(Dispatchers.Main) {
             delay(if (duration == Toast.LENGTH_SHORT) 2500L else 3500L)
             dismiss()
         }

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainContract.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainContract.kt
@@ -14,6 +14,7 @@ data class ArchiveMainState(
     val recentPhotos: ImmutableList<Photo> = persistentListOf(),
     val isShowAddAlbumBottomSheet: Boolean = false,
     val albumNameTextState: TextFieldState = TextFieldState(),
+    val showMarketingAgreementDialog: Boolean = false,
 )
 
 sealed interface ArchiveMainIntent {
@@ -41,6 +42,10 @@ sealed interface ArchiveMainIntent {
     // Add Album BottomSheet Intent
     data object DismissAddAlbumBottomSheet : ArchiveMainIntent
     data object ClickAddAlbumButton : ArchiveMainIntent
+
+    // Marketing Agreement Dialog Intent
+    data object DismissMarketingAgreementDialog : ArchiveMainIntent
+    data object ConfirmMarketingAgreementDialog : ArchiveMainIntent
 }
 
 sealed interface ArchiveMainSideEffect {

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainScreen.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainScreen.kt
@@ -44,6 +44,7 @@ import com.neki.android.feature.archive.impl.main.component.ArchiveMainTitleRow
 import com.neki.android.feature.archive.impl.main.component.ArchiveMainTopBar
 import com.neki.android.feature.archive.impl.component.EmptyPhotoContent
 import com.neki.android.feature.archive.impl.main.component.GotoTopButton
+import com.neki.android.feature.archive.impl.main.component.MarketingAgreementDialog
 import kotlinx.collections.immutable.persistentListOf
 
 @Composable
@@ -129,6 +130,14 @@ internal fun ArchiveMainScreen(
 
     if (uiState.isLoading) {
         LoadingDialog()
+    }
+
+    if (uiState.showMarketingAgreementDialog) {
+        MarketingAgreementDialog(
+            onDismissRequest = { onIntent(ArchiveMainIntent.DismissMarketingAgreementDialog) },
+            onClickConfirm = { onIntent(ArchiveMainIntent.ConfirmMarketingAgreementDialog) },
+            onClickDismiss = { onIntent(ArchiveMainIntent.DismissMarketingAgreementDialog) },
+        )
     }
 
     if (uiState.isShowAddAlbumBottomSheet) {

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.neki.android.core.analytics.event.ArchiveAnalyticsEvent
 import com.neki.android.core.analytics.logger.AnalyticsLogger
+import com.neki.android.core.common.const.TermConst
 import com.neki.android.core.dataapi.repository.FolderRepository
 import com.neki.android.core.dataapi.repository.PhotoRepository
+import com.neki.android.core.dataapi.repository.TermRepository
 import com.neki.android.core.dataapi.repository.UserRepository
 import com.neki.android.core.model.Photo
 import com.neki.android.core.ui.MviIntentStore
@@ -28,6 +30,7 @@ class ArchiveMainViewModel @Inject constructor(
     private val photoRepository: PhotoRepository,
     private val folderRepository: FolderRepository,
     private val userRepository: UserRepository,
+    private val termRepository: TermRepository,
     private val analyticsLogger: AnalyticsLogger,
 ) : ViewModel() {
 
@@ -88,6 +91,13 @@ class ArchiveMainViewModel @Inject constructor(
             // Add Album BottomSheet Intent
             ArchiveMainIntent.DismissAddAlbumBottomSheet -> reduce { copy(isShowAddAlbumBottomSheet = false) }
             ArchiveMainIntent.ClickAddAlbumButton -> handleAddAlbum(state.albumNameTextState.text.trim().toString(), reduce, postSideEffect)
+
+            // Marketing Agreement Dialog Intent
+            ArchiveMainIntent.DismissMarketingAgreementDialog -> reduce { copy(showMarketingAgreementDialog = false) }
+            ArchiveMainIntent.ConfirmMarketingAgreementDialog -> {
+                reduce { copy(showMarketingAgreementDialog = false) }
+                agreeMarketingTerm(postSideEffect)
+            }
         }
     }
 
@@ -102,10 +112,29 @@ class ArchiveMainViewModel @Inject constructor(
                     async { fetchFavoriteSummary(reduce) },
                     async { fetchPhotos(reduce) },
                     async { fetchFolders(reduce) },
+                    async { checkMarketingPopup(reduce) },
                 )
             } finally {
                 reduce { copy(isLoading = false) }
             }
+        }
+    }
+
+    private suspend fun checkMarketingPopup(reduce: (ArchiveMainState.() -> ArchiveMainState) -> Unit) {
+        val userInfo = userRepository.getUserInfo().getOrNull() ?: return
+        if (userInfo.isMarketingTermAgreed) return
+
+        val shownCount = userRepository.archiveMarketingPopupShownCount.first()
+        if (shownCount >= 2) return
+
+        val lastTimestamp = userRepository.lastArchiveMarketingPopupTimestamp.first()
+        val isFirstTime = shownCount == 0
+        val isSevenDaysElapsed = (System.currentTimeMillis() - lastTimestamp) >= TermConst.MARKETING_POPUP_INTERVAL_MS
+        val shouldShow = isFirstTime || isSevenDaysElapsed
+
+        if (shouldShow) {
+            userRepository.recordMarketingPopupShown()
+            reduce { copy(showMarketingAgreementDialog = true) }
         }
     }
 
@@ -170,6 +199,18 @@ class ArchiveMainViewModel @Inject constructor(
                     }
                 }
         }
+    }
+
+    private fun agreeMarketingTerm(
+        postSideEffect: (ArchiveMainSideEffect) -> Unit,
+    ) = viewModelScope.launch {
+        termRepository.updateTermAgreement(termId = TermConst.MARKETING_TERM_ID, agreed = true)
+            .onSuccess {
+                postSideEffect(ArchiveMainSideEffect.ShowToastMessage("마케팅 알림 수신에 동의했어요."))
+            }
+            .onFailure { e ->
+                Timber.e(e)
+            }
     }
 
     private fun handleAddAlbum(

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/component/MarketingAgreementDialog.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/component/MarketingAgreementDialog.kt
@@ -1,0 +1,54 @@
+package com.neki.android.feature.archive.impl.main.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import com.neki.android.core.designsystem.ComponentPreview
+import com.neki.android.core.designsystem.dialog.DoubleButtonSubContentDialog
+import com.neki.android.core.designsystem.ui.theme.NekiTheme
+
+@Composable
+internal fun MarketingAgreementDialog(
+    onDismissRequest: () -> Unit = {},
+    onClickConfirm: () -> Unit = {},
+    onClickDismiss: () -> Unit = {},
+) {
+    DoubleButtonSubContentDialog(
+        title = "놓치지 마세요!",
+        content = "네키의 이벤트, 혜택, 프로모션,\n신규 업데이트 소식을 선별해서 알려드려요.",
+        grayButtonText = "괜찮아요",
+        primaryButtonText = "네, 알려주세요",
+        onDismissRequest = onDismissRequest,
+        onClickPrimaryButton = onClickConfirm,
+        onClickGrayButton = onClickDismiss,
+        subContent = {
+            val highlightText = "마이페이지 > 권한 설정 > 알림 설정"
+            val fullText = "마케팅 정보 푸시 수신 동의 여부는 ${highlightText}에서 변경 가능해요."
+            val annotatedText = buildAnnotatedString {
+                val highlightStart = fullText.indexOf(highlightText)
+                append(fullText.substring(0, highlightStart))
+                withStyle(SpanStyle(color = NekiTheme.colorScheme.primary400)) {
+                    append(highlightText)
+                }
+                append(fullText.substring(highlightStart + highlightText.length))
+            }
+            Text(
+                text = annotatedText,
+                style = NekiTheme.typography.body14Medium,
+                color = NekiTheme.colorScheme.gray900,
+                textAlign = TextAlign.Center,
+            )
+        },
+    )
+}
+
+@ComponentPreview
+@Composable
+private fun MarketingAgreementDialogPreview() {
+    NekiTheme {
+        MarketingAgreementDialog()
+    }
+}

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/component/PermissionSectionItem.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/component/PermissionSectionItem.kt
@@ -23,11 +23,12 @@ import com.neki.android.core.designsystem.ui.theme.NekiTheme
 internal fun PermissionSectionItem(
     type: String,
     subTitle: String,
+    modifier: Modifier = Modifier,
     onClick: () -> Unit = {},
     trailingContent: @Composable () -> Unit = {},
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .noRippleClickableSingle(onClick = onClick)
             .padding(vertical = 12.dp, horizontal = 20.dp),

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/component/PermissionSectionItem.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/component/PermissionSectionItem.kt
@@ -23,8 +23,8 @@ import com.neki.android.core.designsystem.ui.theme.NekiTheme
 internal fun PermissionSectionItem(
     type: String,
     subTitle: String,
-    isGranted: Boolean,
     onClick: () -> Unit = {},
+    trailingContent: @Composable () -> Unit = {},
 ) {
     Row(
         modifier = Modifier
@@ -48,21 +48,7 @@ internal fun PermissionSectionItem(
                 style = NekiTheme.typography.body14Medium,
             )
         }
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = if (isGranted) "허용됨" else "허용안됨",
-                color = NekiTheme.colorScheme.gray500,
-                style = NekiTheme.typography.body14Medium,
-            )
-            Icon(
-                modifier = Modifier.size(16.dp),
-                imageVector = ImageVector.vectorResource(R.drawable.icon_arrow_right),
-                tint = NekiTheme.colorScheme.gray300,
-                contentDescription = null,
-            )
-        }
+        trailingContent()
     }
 }
 
@@ -73,7 +59,21 @@ private fun PermissionSectionItemCameraPreview() {
         PermissionSectionItem(
             type = "카메라",
             subTitle = "QR 촬영에 필요해요.",
-            isGranted = true,
+            trailingContent = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "허용됨",
+                        color = NekiTheme.colorScheme.gray500,
+                        style = NekiTheme.typography.body14Medium,
+                    )
+                    Icon(
+                        modifier = Modifier.size(16.dp),
+                        imageVector = ImageVector.vectorResource(R.drawable.icon_arrow_right),
+                        tint = NekiTheme.colorScheme.gray300,
+                        contentDescription = null,
+                    )
+                }
+            },
         )
     }
 }
@@ -85,7 +85,21 @@ private fun PermissionSectionItemLocationPreview() {
         PermissionSectionItem(
             type = "위치",
             subTitle = "QR 촬영에 필요해요.",
-            isGranted = false,
+            trailingContent = {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "허용안됨",
+                        color = NekiTheme.colorScheme.gray500,
+                        style = NekiTheme.typography.body14Medium,
+                    )
+                    Icon(
+                        modifier = Modifier.size(16.dp),
+                        imageVector = ImageVector.vectorResource(R.drawable.icon_arrow_right),
+                        tint = NekiTheme.colorScheme.gray300,
+                        contentDescription = null,
+                    )
+                }
+            },
         )
     }
 }

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/component/SectionTitleText.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/component/SectionTitleText.kt
@@ -28,8 +28,8 @@ internal fun SectionTitleText(
                 bottom = paddingBottom,
             ),
         text = text,
-        style = NekiTheme.typography.body14Medium,
-        color = NekiTheme.colorScheme.gray400,
+        style = NekiTheme.typography.body14Regular,
+        color = NekiTheme.colorScheme.gray300,
     )
 }
 

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/main/MyPageContract.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/main/MyPageContract.kt
@@ -2,7 +2,6 @@ package com.neki.android.feature.mypage.impl.main
 
 import com.neki.android.core.model.UserInfo
 import com.neki.android.feature.mypage.impl.main.const.ServiceInfoMenu
-import com.neki.android.core.common.permission.NekiPermission
 import com.neki.android.feature.mypage.impl.profile.model.EditProfileImageType
 
 data class MyPageState(
@@ -13,12 +12,6 @@ data class MyPageState(
     val isShowLogoutDialog: Boolean = false,
     val isShowWithdrawDialog: Boolean = false,
     val isShowImageSelectDialog: Boolean = false,
-    // Permission
-    val isGrantedCamera: Boolean = false,
-    val isGrantedLocation: Boolean = false,
-    val isGrantedNotification: Boolean = false,
-    val isShowPermissionDialog: Boolean = false,
-    val clickedPermission: NekiPermission? = null,
 )
 
 sealed interface MyPageIntent {
@@ -46,13 +39,6 @@ sealed interface MyPageIntent {
     data object ClickWithdraw : MyPageIntent
     data object DismissWithdrawDialog : MyPageIntent
     data object ConfirmWithdraw : MyPageIntent
-
-    // Permission
-    data class ClickPermissionItem(val permission: NekiPermission) : MyPageIntent
-    data object DismissPermissionDialog : MyPageIntent
-    data object ConfirmPermissionDialog : MyPageIntent
-    data class UpdatePermissionState(val permission: NekiPermission, val isGranted: Boolean) : MyPageIntent
-    data class ShowPermissionDeniedDialog(val permission: NekiPermission) : MyPageIntent
 }
 
 sealed interface MyPageEffect {
@@ -62,8 +48,6 @@ sealed interface MyPageEffect {
     data object NavigateToPermission : MyPageEffect
     data class OpenExternalLink(val url: String) : MyPageEffect
     data object NavigateBack : MyPageEffect
-    data class MoveAppSettings(val permission: NekiPermission) : MyPageEffect
-    data class RequestPermission(val permission: NekiPermission) : MyPageEffect
     data object OpenOssLicenses : MyPageEffect
     data object LogoutWithKakao : MyPageEffect
     data object UnlinkWithKakao : MyPageEffect

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/main/MyPageViewModel.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/main/MyPageViewModel.kt
@@ -10,7 +10,6 @@ import com.neki.android.core.dataapi.repository.UserRepository
 import com.neki.android.core.domain.usecase.UploadProfileImageUseCase
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
-import com.neki.android.core.common.permission.NekiPermission
 import com.neki.android.feature.mypage.impl.profile.model.EditProfileImageType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.async
@@ -47,6 +46,7 @@ internal class MyPageViewModel @Inject constructor(
         when (intent) {
             MyPageIntent.EnterMypageScreen -> fetchInitialData(reduce)
             is MyPageIntent.SetAppVersion -> reduce { copy(appVersion = intent.appVersion) }
+
             // MyPage Main
             MyPageIntent.ClickNotificationIcon -> postSideEffect(MyPageEffect.NavigateToNotification)
             MyPageIntent.ClickProfileCard -> postSideEffect(MyPageEffect.NavigateToProfile)
@@ -59,7 +59,6 @@ internal class MyPageViewModel @Inject constructor(
                 reduce { copy(profileImageState = EditProfileImageType.OriginalImageUrl(state.userInfo.profileImageUrl)) }
                 postSideEffect(MyPageEffect.NavigateBack)
             }
-
             MyPageIntent.ClickEditIcon -> postSideEffect(MyPageEffect.NavigateToEditProfile)
             MyPageIntent.ClickCameraIcon -> reduce { copy(isShowImageSelectDialog = true) }
             MyPageIntent.DismissImageSelectDialog -> reduce { copy(isShowImageSelectDialog = false) }
@@ -82,35 +81,6 @@ internal class MyPageViewModel @Inject constructor(
             MyPageIntent.ConfirmWithdraw -> {
                 reduce { copy(isShowWithdrawDialog = false) }
                 withdrawAccount(reduce, postSideEffect)
-            }
-
-            // Permission
-            is MyPageIntent.ClickPermissionItem -> {
-                postSideEffect(MyPageEffect.RequestPermission(intent.permission))
-            }
-
-            MyPageIntent.DismissPermissionDialog -> {
-                reduce { copy(isShowPermissionDialog = false, clickedPermission = null) }
-            }
-
-            MyPageIntent.ConfirmPermissionDialog -> {
-                val permission = state.clickedPermission
-                reduce { copy(isShowPermissionDialog = false, clickedPermission = null) }
-                if (permission != null) {
-                    postSideEffect(MyPageEffect.MoveAppSettings(permission))
-                }
-            }
-
-            is MyPageIntent.UpdatePermissionState -> {
-                when (intent.permission) {
-                    NekiPermission.CAMERA -> reduce { copy(isGrantedCamera = intent.isGranted) }
-                    NekiPermission.LOCATION -> reduce { copy(isGrantedLocation = intent.isGranted) }
-                    NekiPermission.NOTIFICATION -> reduce { copy(isGrantedNotification = intent.isGranted) }
-                }
-            }
-
-            is MyPageIntent.ShowPermissionDeniedDialog -> {
-                reduce { copy(isShowPermissionDialog = true, clickedPermission = intent.permission) }
             }
         }
     }
@@ -164,7 +134,6 @@ internal class MyPageViewModel @Inject constructor(
                         userInfo = user,
                     )
                 }
-
                 if (isProfileImageChanged) {
                     postSideEffect(MyPageEffect.PreloadImageAndNavigateBack(user.profileImageUrl))
                 } else {

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/navigation/MyPageEntryProvider.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/navigation/MyPageEntryProvider.kt
@@ -48,11 +48,7 @@ private fun EntryProviderScope<NavKey>.myPageEntry(
         )
     }
 
-    entry<MyPageNavKey.Permission>(
-        metadata = HiltSharedViewModelStoreNavEntryDecorator.parent(
-            MyPageNavKey.MyPage.toString(),
-        ),
-    ) {
+    entry<MyPageNavKey.Permission> {
         PermissionRoute(
             navigateBack = mainNavigator::goBack,
         )

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionContract.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionContract.kt
@@ -25,9 +25,8 @@ sealed interface PermissionIntent {
     data class ShowPermissionDeniedDialog(val permission: NekiPermission) : PermissionIntent
 
     data object ToggleMarketingNotification : PermissionIntent
-    data class MarketingNotificationCommitted(val newValue: Boolean) : PermissionIntent
+    data class MarketingNotificationCommitted(val newValue: Boolean, val toastMessage: String) : PermissionIntent
     data class RevertMarketingNotification(val originalValue: Boolean) : PermissionIntent
-    data class ShowMarketingToast(val message: String) : PermissionIntent
 }
 
 sealed interface PermissionEffect {

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionContract.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionContract.kt
@@ -1,16 +1,15 @@
 package com.neki.android.feature.mypage.impl.permission
 
 import com.neki.android.core.common.permission.NekiPermission
-import com.neki.android.core.model.UserInfo
 
 data class PermissionState(
     val isLoading: Boolean = false,
-    val userInfo: UserInfo = UserInfo(),
-    val committedMarketingNotification: Boolean = false,
     val isGrantedCamera: Boolean = false,
     val isGrantedLocation: Boolean = false,
     val isGrantedNotification: Boolean = false,
     val isShowPermissionDialog: Boolean = false,
+    val isMarketingTermAgreed: Boolean = false,
+    val committedMarketingNotification: Boolean = false,
     val clickedPermission: NekiPermission? = null,
 )
 

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionContract.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionContract.kt
@@ -27,6 +27,7 @@ sealed interface PermissionIntent {
     data object ToggleMarketingNotification : PermissionIntent
     data class MarketingNotificationCommitted(val newValue: Boolean) : PermissionIntent
     data class RevertMarketingNotification(val originalValue: Boolean) : PermissionIntent
+    data class ShowMarketingToast(val message: String) : PermissionIntent
 }
 
 sealed interface PermissionEffect {

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionContract.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionContract.kt
@@ -1,0 +1,37 @@
+package com.neki.android.feature.mypage.impl.permission
+
+import com.neki.android.core.common.permission.NekiPermission
+import com.neki.android.core.model.UserInfo
+
+data class PermissionState(
+    val isLoading: Boolean = false,
+    val userInfo: UserInfo = UserInfo(),
+    val committedMarketingNotification: Boolean = false,
+    val isGrantedCamera: Boolean = false,
+    val isGrantedLocation: Boolean = false,
+    val isGrantedNotification: Boolean = false,
+    val isShowPermissionDialog: Boolean = false,
+    val clickedPermission: NekiPermission? = null,
+)
+
+sealed interface PermissionIntent {
+    data object EnterPermissionScreen : PermissionIntent
+
+    data object ClickBackIcon : PermissionIntent
+    data class ClickPermissionItem(val permission: NekiPermission) : PermissionIntent
+    data object DismissPermissionDialog : PermissionIntent
+    data object ConfirmPermissionDialog : PermissionIntent
+    data class UpdatePermissionState(val permission: NekiPermission, val isGranted: Boolean) : PermissionIntent
+    data class ShowPermissionDeniedDialog(val permission: NekiPermission) : PermissionIntent
+
+    data object ToggleMarketingNotification : PermissionIntent
+    data class MarketingNotificationCommitted(val newValue: Boolean) : PermissionIntent
+    data class RevertMarketingNotification(val originalValue: Boolean) : PermissionIntent
+}
+
+sealed interface PermissionEffect {
+    data object NavigateBack : PermissionEffect
+    data class RequestPermission(val permission: NekiPermission) : PermissionEffect
+    data class MoveAppSettings(val permission: NekiPermission) : PermissionEffect
+    data class ShowToast(val message: String) : PermissionEffect
+}

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionScreen.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionScreen.kt
@@ -99,10 +99,6 @@ internal fun PermissionRoute(
         }
     }
 
-    viewModel.toastMessage.collectWithLifecycle { message ->
-        nekiToast.showToast(text = message)
-    }
-
     viewModel.store.sideEffects.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             PermissionEffect.NavigateBack -> navigateBack()

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionScreen.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionScreen.kt
@@ -175,7 +175,7 @@ fun PermissionScreen(
             subTitle = "이벤트, 혜택, 신규 기능 소식 등을 알려드려요.",
             trailingContent = {
                 NekiToggle(
-                    checked = uiState.userInfo.isMarketingTermAgreed,
+                    checked = uiState.isMarketingTermAgreed,
                     onCheckedChange = { onIntent(PermissionIntent.ToggleMarketingNotification) },
                 )
             },

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionScreen.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionScreen.kt
@@ -5,45 +5,56 @@ import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.neki.android.core.common.permission.CameraPermissionManager
 import com.neki.android.core.common.permission.LocationPermissionManager
 import com.neki.android.core.common.permission.NotificationPermissionManager
+import com.neki.android.core.common.permission.NekiPermission
 import com.neki.android.core.common.permission.navigateToAppSettings
 import com.neki.android.core.designsystem.ComponentPreview
+import com.neki.android.core.designsystem.R
 import com.neki.android.core.designsystem.dialog.DoubleButtonAlertDialog
 import com.neki.android.core.designsystem.topbar.BackTitleTopBar
+import com.neki.android.core.designsystem.toggle.NekiToggle
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.ui.compose.collectWithLifecycle
+import com.neki.android.core.ui.compose.VerticalSpacer
+import com.neki.android.core.ui.component.LoadingDialog
+import com.neki.android.core.ui.toast.NekiToast
 import com.neki.android.feature.mypage.impl.component.PermissionSectionItem
 import com.neki.android.feature.mypage.impl.component.SectionTitleText
-import com.neki.android.feature.mypage.impl.main.MyPageEffect
-import com.neki.android.feature.mypage.impl.main.MyPageIntent
-import com.neki.android.feature.mypage.impl.main.MyPageState
-import com.neki.android.feature.mypage.impl.main.MyPageViewModel
-import com.neki.android.core.common.permission.NekiPermission
 
 @Composable
 internal fun PermissionRoute(
-    viewModel: MyPageViewModel = hiltViewModel(),
+    viewModel: PermissionViewModel = hiltViewModel(),
     navigateBack: () -> Unit = {},
 ) {
     val uiState by viewModel.store.uiState.collectAsStateWithLifecycle()
     val activity = LocalActivity.current!!
     val context = LocalContext.current
+    val nekiToast = remember { NekiToast(context) }
 
     fun checkPermissions() {
         NekiPermission.entries.forEach { permission ->
             viewModel.store.onIntent(
-                MyPageIntent.UpdatePermissionState(
+                PermissionIntent.UpdatePermissionState(
                     permission = permission,
                     isGranted = when (permission) {
                         NekiPermission.CAMERA -> CameraPermissionManager.isGrantedCameraPermission(context)
@@ -74,7 +85,7 @@ internal fun PermissionRoute(
             else -> return@rememberLauncherForActivityResult
         }
         val isGranted = permissions.values.any { it }
-        viewModel.store.onIntent(MyPageIntent.UpdatePermissionState(permission, isGranted))
+        viewModel.store.onIntent(PermissionIntent.UpdatePermissionState(permission, isGranted))
 
         if (!isGranted) {
             val shouldShowRationale = when (permission) {
@@ -83,15 +94,19 @@ internal fun PermissionRoute(
                 NekiPermission.NOTIFICATION -> NotificationPermissionManager.shouldShowNotificationRationale(activity)
             }
             if (!shouldShowRationale) {
-                viewModel.store.onIntent(MyPageIntent.ShowPermissionDeniedDialog(permission))
+                viewModel.store.onIntent(PermissionIntent.ShowPermissionDeniedDialog(permission))
             }
         }
     }
 
+    viewModel.toastMessage.collectWithLifecycle { message ->
+        nekiToast.showToast(text = message)
+    }
+
     viewModel.store.sideEffects.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
-            MyPageEffect.NavigateBack -> navigateBack()
-            is MyPageEffect.RequestPermission -> {
+            PermissionEffect.NavigateBack -> navigateBack()
+            is PermissionEffect.RequestPermission -> {
                 when (sideEffect.permission) {
                     NekiPermission.CAMERA -> permissionLauncher.launch(arrayOf(CameraPermissionManager.CAMERA_PERMISSION))
                     NekiPermission.LOCATION -> permissionLauncher.launch(LocationPermissionManager.LOCATION_PERMISSIONS)
@@ -100,15 +115,14 @@ internal fun PermissionRoute(
                             permissionLauncher.launch(arrayOf(NotificationPermissionManager.NOTIFICATION_PERMISSION))
                         } else {
                             if (!NotificationPermissionManager.isGrantedNotificationPermission(context)) {
-                                viewModel.store.onIntent(MyPageIntent.ShowPermissionDeniedDialog(NekiPermission.NOTIFICATION))
+                                viewModel.store.onIntent(PermissionIntent.ShowPermissionDeniedDialog(NekiPermission.NOTIFICATION))
                             }
                         }
                     }
                 }
             }
-
-            is MyPageEffect.MoveAppSettings -> navigateToAppSettings(context)
-            else -> {}
+            is PermissionEffect.MoveAppSettings -> navigateToAppSettings(context)
+            is PermissionEffect.ShowToast -> nekiToast.showToast(text = sideEffect.message)
         }
     }
 
@@ -120,29 +134,60 @@ internal fun PermissionRoute(
 
 @Composable
 fun PermissionScreen(
-    uiState: MyPageState = MyPageState(),
-    onIntent: (MyPageIntent) -> Unit = {},
+    uiState: PermissionState = PermissionState(),
+    onIntent: (PermissionIntent) -> Unit = {},
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
     ) {
         BackTitleTopBar(
-            title = "기기 권한",
-            onBack = { onIntent(MyPageIntent.ClickBackIcon) },
+            title = "기기 권한 및 알림",
+            onBack = { onIntent(PermissionIntent.ClickBackIcon) },
         )
         SectionTitleText(text = "권한 설정")
         NekiPermission.entries.forEach { permission ->
+            val isGranted = when (permission) {
+                NekiPermission.CAMERA -> uiState.isGrantedCamera
+                NekiPermission.LOCATION -> uiState.isGrantedLocation
+                NekiPermission.NOTIFICATION -> uiState.isGrantedNotification
+            }
             PermissionSectionItem(
                 type = permission.type,
                 subTitle = permission.subTitle,
-                isGranted = when (permission) {
-                    NekiPermission.CAMERA -> uiState.isGrantedCamera
-                    NekiPermission.LOCATION -> uiState.isGrantedLocation
-                    NekiPermission.NOTIFICATION -> uiState.isGrantedNotification
+                onClick = { onIntent(PermissionIntent.ClickPermissionItem(permission)) },
+                trailingContent = {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = if (isGranted) "허용됨" else "허용안됨",
+                            color = NekiTheme.colorScheme.gray500,
+                            style = NekiTheme.typography.body14Medium,
+                        )
+                        Icon(
+                            modifier = Modifier.size(16.dp),
+                            imageVector = ImageVector.vectorResource(R.drawable.icon_arrow_right),
+                            tint = NekiTheme.colorScheme.gray300,
+                            contentDescription = null,
+                        )
+                    }
                 },
-                onClick = { onIntent(MyPageIntent.ClickPermissionItem(permission)) },
             )
         }
+        VerticalSpacer(12.dp)
+        SectionTitleText(text = "알람 설정")
+        PermissionSectionItem(
+            type = "혜택·소식 알림",
+            subTitle = "이벤트, 혜택, 신규 기능 소식 등을 알려드려요.",
+            trailingContent = {
+                NekiToggle(
+                    checked = uiState.userInfo.isMarketingTermAgreed,
+                    onCheckedChange = { onIntent(PermissionIntent.ToggleMarketingNotification) },
+                )
+            },
+        )
+    }
+
+    if (uiState.isLoading) {
+        LoadingDialog()
     }
 
     if (uiState.isShowPermissionDialog && uiState.clickedPermission != null) {
@@ -151,9 +196,9 @@ fun PermissionScreen(
             content = uiState.clickedPermission.dialogContent,
             grayButtonText = "취소",
             primaryButtonText = "허용",
-            onDismissRequest = { onIntent(MyPageIntent.DismissPermissionDialog) },
-            onClickGrayButton = { onIntent(MyPageIntent.DismissPermissionDialog) },
-            onClickPrimaryButton = { onIntent(MyPageIntent.ConfirmPermissionDialog) },
+            onDismissRequest = { onIntent(PermissionIntent.DismissPermissionDialog) },
+            onClickGrayButton = { onIntent(PermissionIntent.DismissPermissionDialog) },
+            onClickPrimaryButton = { onIntent(PermissionIntent.ConfirmPermissionDialog) },
         )
     }
 }

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionViewModel.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionViewModel.kt
@@ -95,8 +95,8 @@ internal class PermissionViewModel @Inject constructor(
                 reduce { copy(isShowPermissionDialog = true, clickedPermission = intent.permission) }
 
             PermissionIntent.ToggleMarketingNotification -> {
-                val newValue = !state.userInfo.isMarketingTermAgreed
-                reduce { copy(userInfo = userInfo.copy(isMarketingTermAgreed = newValue)) }
+                val newValue = !state.isMarketingTermAgreed
+                reduce { copy(isMarketingTermAgreed = newValue) }
                 viewModelScope.launch { marketingToggleRequests.emit(newValue) }
             }
 
@@ -106,7 +106,7 @@ internal class PermissionViewModel @Inject constructor(
             }
 
             is PermissionIntent.RevertMarketingNotification ->
-                reduce { copy(userInfo = userInfo.copy(isMarketingTermAgreed = intent.originalValue)) }
+                reduce { copy(isMarketingTermAgreed = intent.originalValue) }
         }
     }
 
@@ -118,7 +118,7 @@ internal class PermissionViewModel @Inject constructor(
                     reduce {
                         copy(
                             isLoading = false,
-                            userInfo = user,
+                            isMarketingTermAgreed = user.isMarketingTermAgreed,
                             committedMarketingNotification = user.isMarketingTermAgreed,
                         )
                     }
@@ -131,7 +131,7 @@ internal class PermissionViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        val current = store.uiState.value.userInfo.isMarketingTermAgreed
+        val current = store.uiState.value.isMarketingTermAgreed
         val committed = store.uiState.value.committedMarketingNotification
         if (current != committed) {
             applicationScope.launch {

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionViewModel.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionViewModel.kt
@@ -13,7 +13,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -28,9 +27,6 @@ internal class PermissionViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val marketingToggleRequests = MutableSharedFlow<Boolean>(extraBufferCapacity = 64)
-
-    private val _toastMessage = MutableSharedFlow<String>(extraBufferCapacity = 8)
-    val toastMessage = _toastMessage.asSharedFlow()
 
     val store: MviIntentStore<PermissionState, PermissionIntent, PermissionEffect> =
         mviIntentStore(
@@ -55,7 +51,7 @@ internal class PermissionViewModel @Inject constructor(
                                 } else {
                                     "마케팅 알림 수신을 거부했어요.\n마이페이지에서 언제든지 변경할 수 있어요."
                                 }
-                                _toastMessage.emit(message)
+                                store.onIntent(PermissionIntent.ShowMarketingToast(message))
                             }
                             .onFailure { e ->
                                 Timber.e(e, "updateMarketingTerm failed")
@@ -110,6 +106,9 @@ internal class PermissionViewModel @Inject constructor(
 
             is PermissionIntent.RevertMarketingNotification ->
                 reduce { copy(userInfo = userInfo.copy(isMarketingTermAgreed = intent.originalValue)) }
+
+            is PermissionIntent.ShowMarketingToast ->
+                postSideEffect(PermissionEffect.ShowToast(intent.message))
         }
     }
 

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionViewModel.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionViewModel.kt
@@ -1,0 +1,145 @@
+package com.neki.android.feature.mypage.impl.permission
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.neki.android.core.common.const.TermConst
+import com.neki.android.core.common.coroutine.di.ApplicationScope
+import com.neki.android.core.common.permission.NekiPermission
+import com.neki.android.core.dataapi.repository.TermRepository
+import com.neki.android.core.dataapi.repository.UserRepository
+import com.neki.android.core.ui.MviIntentStore
+import com.neki.android.core.ui.mviIntentStore
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@OptIn(FlowPreview::class)
+@HiltViewModel
+internal class PermissionViewModel @Inject constructor(
+    private val userRepository: UserRepository,
+    private val termRepository: TermRepository,
+    @ApplicationScope private val applicationScope: CoroutineScope,
+) : ViewModel() {
+
+    private val marketingToggleRequests = MutableSharedFlow<Boolean>(extraBufferCapacity = 64)
+
+    private val _toastMessage = MutableSharedFlow<String>(extraBufferCapacity = 8)
+    val toastMessage = _toastMessage.asSharedFlow()
+
+    val store: MviIntentStore<PermissionState, PermissionIntent, PermissionEffect> =
+        mviIntentStore(
+            initialState = PermissionState(),
+            onIntent = ::onIntent,
+        )
+
+    init {
+        store.onIntent(PermissionIntent.EnterPermissionScreen)
+
+        viewModelScope.launch {
+            marketingToggleRequests
+                .debounce(300)
+                .collect { newValue ->
+                    val committed = store.uiState.value.committedMarketingNotification
+                    if (committed != newValue) {
+                        termRepository.updateTermAgreement(TermConst.MARKETING_TERM_ID, newValue)
+                            .onSuccess {
+                                store.onIntent(PermissionIntent.MarketingNotificationCommitted(newValue))
+                                val message = if (newValue) {
+                                    "마케팅 알림 수신에 동의했어요."
+                                } else {
+                                    "마케팅 알림 수신을 거부했어요.\n마이페이지에서 언제든지 변경할 수 있어요."
+                                }
+                                _toastMessage.emit(message)
+                            }
+                            .onFailure { e ->
+                                Timber.e(e, "updateMarketingTerm failed")
+                                store.onIntent(PermissionIntent.RevertMarketingNotification(committed))
+                            }
+                    }
+                }
+        }
+    }
+
+    private fun onIntent(
+        intent: PermissionIntent,
+        state: PermissionState,
+        reduce: (PermissionState.() -> PermissionState) -> Unit,
+        postSideEffect: (PermissionEffect) -> Unit,
+    ) {
+        when (intent) {
+            PermissionIntent.EnterPermissionScreen -> fetchUserInfo(reduce)
+            PermissionIntent.ClickBackIcon -> postSideEffect(PermissionEffect.NavigateBack)
+
+            is PermissionIntent.ClickPermissionItem ->
+                postSideEffect(PermissionEffect.RequestPermission(intent.permission))
+
+            PermissionIntent.DismissPermissionDialog ->
+                reduce { copy(isShowPermissionDialog = false, clickedPermission = null) }
+
+            PermissionIntent.ConfirmPermissionDialog -> {
+                val permission = state.clickedPermission
+                reduce { copy(isShowPermissionDialog = false, clickedPermission = null) }
+                if (permission != null) postSideEffect(PermissionEffect.MoveAppSettings(permission))
+            }
+
+            is PermissionIntent.UpdatePermissionState -> {
+                when (intent.permission) {
+                    NekiPermission.CAMERA -> reduce { copy(isGrantedCamera = intent.isGranted) }
+                    NekiPermission.LOCATION -> reduce { copy(isGrantedLocation = intent.isGranted) }
+                    NekiPermission.NOTIFICATION -> reduce { copy(isGrantedNotification = intent.isGranted) }
+                }
+            }
+
+            is PermissionIntent.ShowPermissionDeniedDialog ->
+                reduce { copy(isShowPermissionDialog = true, clickedPermission = intent.permission) }
+
+            PermissionIntent.ToggleMarketingNotification -> {
+                val newValue = !state.userInfo.isMarketingTermAgreed
+                reduce { copy(userInfo = userInfo.copy(isMarketingTermAgreed = newValue)) }
+                viewModelScope.launch { marketingToggleRequests.emit(newValue) }
+            }
+
+            is PermissionIntent.MarketingNotificationCommitted ->
+                reduce { copy(committedMarketingNotification = intent.newValue) }
+
+            is PermissionIntent.RevertMarketingNotification ->
+                reduce { copy(userInfo = userInfo.copy(isMarketingTermAgreed = intent.originalValue)) }
+        }
+    }
+
+    private fun fetchUserInfo(reduce: (PermissionState.() -> PermissionState) -> Unit) =
+        viewModelScope.launch {
+            reduce { copy(isLoading = true) }
+            userRepository.getUserInfo()
+                .onSuccess { user ->
+                    reduce {
+                        copy(
+                            isLoading = false,
+                            userInfo = user,
+                            committedMarketingNotification = user.isMarketingTermAgreed,
+                        )
+                    }
+                }
+                .onFailure { e ->
+                    Timber.e(e)
+                    reduce { copy(isLoading = false) }
+                }
+        }
+
+    override fun onCleared() {
+        super.onCleared()
+        val current = store.uiState.value.userInfo.isMarketingTermAgreed
+        val committed = store.uiState.value.committedMarketingNotification
+        if (current != committed) {
+            applicationScope.launch {
+                termRepository.updateTermAgreement(TermConst.MARKETING_TERM_ID, current)
+            }
+        }
+    }
+}

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionViewModel.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/permission/PermissionViewModel.kt
@@ -45,13 +45,12 @@ internal class PermissionViewModel @Inject constructor(
                     if (committed != newValue) {
                         termRepository.updateTermAgreement(TermConst.MARKETING_TERM_ID, newValue)
                             .onSuccess {
-                                store.onIntent(PermissionIntent.MarketingNotificationCommitted(newValue))
                                 val message = if (newValue) {
                                     "마케팅 알림 수신에 동의했어요."
                                 } else {
                                     "마케팅 알림 수신을 거부했어요.\n마이페이지에서 언제든지 변경할 수 있어요."
                                 }
-                                store.onIntent(PermissionIntent.ShowMarketingToast(message))
+                                store.onIntent(PermissionIntent.MarketingNotificationCommitted(newValue, message))
                             }
                             .onFailure { e ->
                                 Timber.e(e, "updateMarketingTerm failed")
@@ -101,14 +100,13 @@ internal class PermissionViewModel @Inject constructor(
                 viewModelScope.launch { marketingToggleRequests.emit(newValue) }
             }
 
-            is PermissionIntent.MarketingNotificationCommitted ->
+            is PermissionIntent.MarketingNotificationCommitted -> {
                 reduce { copy(committedMarketingNotification = intent.newValue) }
+                postSideEffect(PermissionEffect.ShowToast(intent.toastMessage))
+            }
 
             is PermissionIntent.RevertMarketingNotification ->
                 reduce { copy(userInfo = userInfo.copy(isMarketingTermAgreed = intent.originalValue)) }
-
-            is PermissionIntent.ShowMarketingToast ->
-                postSideEffect(PermissionEffect.ShowToast(intent.message))
         }
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #209

## 📙 작업 설명
- `UserInfo`에 `isMarketingTermAgreed` 필드 추가 및 서버 응답 매핑
- `TermRepository`에 `updateTermAgreement()` 추가 (약관 개별 동의/철회)
- `UserRepository`에 마케팅 팝업 노출 기록 기능 추가 (`recordMarketingPopupShown()` - 타임스탬프 + 노출 횟수 카운팅)
- 아카이브 메인 진입 시 조건부 마케팅 수신동의 팝업 노출 (최대 2회: 최초 1회 + 미동의 상태 7일 경과 후 1회)
- `PermissionViewModel` / `PermissionContract`를 `MyPageViewModel`에서 분리
- Permission 화면 마케팅 알림 토글에 낙관적 업데이트 적용
- `NekiToggle`, `DoubleButtonSubContentDialog` 디자인시스템 컴포넌트 추가

## 🧪 테스트 내역
- 최초 아카이브 진입 시 마케팅 팝업 노출 확인
- 팝업 dismiss 후 7일 이내 재진입 시 미노출 확인(테스트하느라 5분 기준으로 확인)
- 팝업 2회 초과 시 미노출 확인
- 동의한 유저 팝업 미노출 확인
- Permission 화면 토글 ON/OFF UI 즉시 반영 및 서버 동기화 확인

## 📸 스크린샷 또는 시연 영상
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| 신규 가입(미동의) |<video src="https://github.com/user-attachments/assets/e4773822-9f74-41eb-b5f9-ac882419eb10" width="300" />| 미동의 상태로 7일 후 재접속 |<video src="https://github.com/user-attachments/assets/ba0cf479-db8a-48be-bc52-9f06d6d4bb66" width="300" />|
| 토글 ON/OFF |<video src="https://github.com/user-attachments/assets/e2039fc9-8f9c-456e-b1f7-d0a9f30df7ed" width="300" />|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 아카이브 화면에 마케팅 약관 동의 다이얼로그(확인/닫기) 추가 및 “팝업 표시” 상태를 저장해 노출을 제어합니다.
  * 사용자 정보에 마케팅 약관/푸시 동의 여부를 반영하고, 약관 동의 변경을 저장합니다.
  * 권한 화면에 알림(마케팅) 토글을 추가했습니다.
  * 더블 버튼 다이얼로그와 `NekiToggle` 등 재사용 가능한 UI 컴포넌트를 제공합니다.
* **Refactor**
  * 권한 관리 흐름을 별도 화면으로 분리하고, 권한 항목은 후행 UI 슬롯 기반으로 구성하도록 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->