### PR TITLE
[feat] #210 포즈 상세 좌우 스와이프 지원

### DIFF
--- a/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/PoseRepository.kt
+++ b/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/PoseRepository.kt
@@ -3,6 +3,7 @@ package com.neki.android.core.dataapi.repository
 import androidx.paging.PagingData
 import com.neki.android.core.model.PeopleCount
 import com.neki.android.core.model.Pose
+import com.neki.android.core.model.PosePage
 import com.neki.android.core.model.SortOrder
 import kotlinx.coroutines.flow.Flow
 
@@ -16,6 +17,19 @@ interface PoseRepository {
     fun getBookmarkedPosesFlow(
         sortOrder: SortOrder = SortOrder.DESC,
     ): Flow<PagingData<Pose>>
+
+    suspend fun getPosesPage(
+        headCount: PeopleCount? = null,
+        page: Int = 0,
+        size: Int = 20,
+        sortOrder: SortOrder = SortOrder.DESC,
+    ): Result<PosePage>
+
+    suspend fun getBookmarkedPosesPage(
+        page: Int = 0,
+        size: Int = 20,
+        sortOrder: SortOrder = SortOrder.DESC,
+    ): Result<PosePage>
 
     suspend fun getPose(poseId: Long): Result<Pose>
 

--- a/core/data/src/main/java/com/neki/android/core/data/paging/BookmarkPosePagingSource.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/paging/BookmarkPosePagingSource.kt
@@ -14,16 +14,18 @@ class BookmarkPosePagingSource(
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, Pose> {
         return try {
             val page = params.key ?: 0
-            val poses = poseService.getBookmarkedPoses(
+            val response = poseService.getBookmarkedPoses(
                 page = page,
                 size = params.loadSize,
                 sortOrder = sortOrder.name,
-            ).data.toModels()
+            )
+            val poses = response.data.toModels()
+            val hasNext = response.data.hasNext
 
             LoadResult.Page(
                 data = poses,
                 prevKey = if (page == 0) null else page - 1,
-                nextKey = if (poses.isEmpty()) null else page + 1,
+                nextKey = if (hasNext) page + 1 else null,
             )
         } catch (e: Exception) {
             LoadResult.Error(e)

--- a/core/data/src/main/java/com/neki/android/core/data/paging/PosePagingSource.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/paging/PosePagingSource.kt
@@ -23,11 +23,12 @@ class PosePagingSource(
                 sortOrder = sortOrder.name,
             )
             val poses = response.data.toModels()
+            val hasNext = response.data.hasNext
 
             LoadResult.Page(
                 data = poses,
                 prevKey = if (page == 0) null else page - 1,
-                nextKey = if (poses.isEmpty()) null else page + 1,
+                nextKey = if (hasNext) page + 1 else null,
             )
         } catch (e: Exception) {
             LoadResult.Error(e)

--- a/core/data/src/main/java/com/neki/android/core/data/remote/model/response/PoseResponse.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/model/response/PoseResponse.kt
@@ -17,6 +17,8 @@ data class PoseResponse(
         @SerialName("imageUrl") val imageUrl: String,
         @SerialName("scrap") val bookmark: Boolean,
         @SerialName("contentType") val contentType: String,
+        @SerialName("width") val width: Int? = null,
+        @SerialName("height") val height: Int? = null,
         @SerialName("createdAt") val createdAt: String,
     ) {
         internal fun toModel() = Pose(
@@ -24,6 +26,8 @@ data class PoseResponse(
             poseImageUrl = imageUrl,
             peopleCount = PeopleCount.entries.find { it.name == headCount }?.value ?: 1,
             isBookmarked = bookmark,
+            width = width,
+            height = height,
         )
     }
 

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/PoseRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/PoseRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.neki.android.core.data.util.runSuspendCatching
 import com.neki.android.core.dataapi.repository.PoseRepository
 import com.neki.android.core.model.PeopleCount
 import com.neki.android.core.model.Pose
+import com.neki.android.core.model.PosePage
 import com.neki.android.core.model.SortOrder
 import io.ktor.client.plugins.ClientRequestException
 import kotlinx.coroutines.flow.Flow
@@ -62,6 +63,34 @@ class PoseRepositoryImpl @Inject constructor(
                 )
             },
         ).flow
+    }
+
+    override suspend fun getPosesPage(
+        headCount: PeopleCount?,
+        page: Int,
+        size: Int,
+        sortOrder: SortOrder,
+    ): Result<PosePage> = runSuspendCatching {
+        val response = poseService.getPoses(
+            page = page,
+            size = size,
+            headCount = headCount?.name,
+            sortOrder = sortOrder.name,
+        ).data
+        PosePage(poses = response.toModels(), hasNext = response.hasNext)
+    }
+
+    override suspend fun getBookmarkedPosesPage(
+        page: Int,
+        size: Int,
+        sortOrder: SortOrder,
+    ): Result<PosePage> = runSuspendCatching {
+        val response = poseService.getBookmarkedPoses(
+            page = page,
+            size = size,
+            sortOrder = sortOrder.name,
+        ).data
+        PosePage(poses = response.toModels(), hasNext = response.hasNext)
     }
 
     override suspend fun getPose(poseId: Long): Result<Pose> = runSuspendCatching {

--- a/core/model/src/main/java/com/neki/android/core/model/Pose.kt
+++ b/core/model/src/main/java/com/neki/android/core/model/Pose.kt
@@ -10,4 +10,6 @@ data class Pose(
     val poseImageUrl: String = "",
     val isBookmarked: Boolean = false,
     val peopleCount: Int = 0,
+    val width: Int? = null,
+    val height: Int? = null,
 )

--- a/core/model/src/main/java/com/neki/android/core/model/PosePage.kt
+++ b/core/model/src/main/java/com/neki/android/core/model/PosePage.kt
@@ -1,0 +1,6 @@
+package com.neki.android.core.model
+
+data class PosePage(
+    val poses: List<Pose>,
+    val hasNext: Boolean,
+)

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/photo_detail/PhotoDetailViewModel.kt
@@ -298,11 +298,12 @@ class PhotoDetailViewModel @AssistedInject constructor(
     override fun onCleared() {
         super.onCleared()
         val state = store.uiState.value
-        val currentPhoto = state.photo
-        val committedFavorite = committedFavorites[currentPhoto.id] ?: return
-        if (currentPhoto.isFavorite != committedFavorite) {
-            applicationScope.launch {
-                photoRepository.updateFavorite(currentPhoto.id, currentPhoto.isFavorite)
+        state.photos.forEach { photo ->
+            val committedFavorite = committedFavorites[photo.id]
+            if (committedFavorite != null && photo.isFavorite != committedFavorite) {
+                applicationScope.launch {
+                    photoRepository.updateFavorite(photo.id, photo.isFavorite)
+                }
             }
         }
     }

--- a/feature/pose/api/src/main/java/com/neki/android/feature/pose/api/PoseNavKey.kt
+++ b/feature/pose/api/src/main/java/com/neki/android/feature/pose/api/PoseNavKey.kt
@@ -2,6 +2,8 @@ package com.neki.android.feature.pose.api
 
 import androidx.navigation3.runtime.NavKey
 import com.neki.android.core.model.PeopleCount
+import com.neki.android.core.model.Pose
+import com.neki.android.core.model.SortOrder
 import com.neki.android.core.navigation.main.MainNavigator
 import kotlinx.serialization.Serializable
 
@@ -14,7 +16,15 @@ sealed interface PoseNavKey : NavKey {
     data class RandomPose(val peopleCount: PeopleCount) : PoseNavKey
 
     @Serializable
-    data class PoseDetail(val poseId: Long) : PoseNavKey
+    data class PoseDetail(
+        val poseId: Long,
+        val poses: List<Pose> = emptyList(),
+        val initialIndex: Int = 0,
+        val hasNext: Boolean = false,
+        val headCount: PeopleCount? = null,
+        val sortOrder: SortOrder = SortOrder.DESC,
+        val isBookmarkOnly: Boolean = false,
+    ) : PoseNavKey
 }
 
 fun MainNavigator.navigateToPose() {
@@ -27,4 +37,8 @@ fun MainNavigator.navigateToRandomPose(peopleCount: PeopleCount) {
 
 fun MainNavigator.navigateToPoseDetail(poseId: Long) {
     navigate(PoseNavKey.PoseDetail(poseId))
+}
+
+fun MainNavigator.navigateToPoseDetail(poseDetail: PoseNavKey.PoseDetail) {
+    navigate(poseDetail)
 }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailContract.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailContract.kt
@@ -4,16 +4,21 @@ import com.neki.android.core.model.Pose
 
 data class PoseDetailState(
     val isLoading: Boolean = false,
-    val pose: Pose = Pose(),
-    val committedBookmark: Boolean = false,
-)
+    val poses: List<Pose> = emptyList(),
+    val currentPage: Int = 0,
+    val committedBookmarks: Map<Long, Boolean> = emptyMap(),
+) {
+    val currentIndex: Int get() = if (poses.isEmpty()) 0 else currentPage.coerceIn(0, poses.lastIndex)
+    val pose: Pose get() = poses.getOrElse(currentIndex) { Pose() }
+}
 
 sealed interface PoseDetailIntent {
     data object EnterPoseDetailScreen : PoseDetailIntent
     data object ClickBackIcon : PoseDetailIntent
+    data class PageChanged(val page: Int) : PoseDetailIntent
     data object ClickBookmarkIcon : PoseDetailIntent
-    data class BookmarkCommitted(val newBookmark: Boolean) : PoseDetailIntent
-    data class RevertBookmark(val originalBookmark: Boolean) : PoseDetailIntent
+    data class BookmarkCommitted(val poseId: Long, val newBookmark: Boolean) : PoseDetailIntent
+    data class RevertBookmark(val poseId: Long, val originalBookmark: Boolean) : PoseDetailIntent
 }
 
 sealed interface PoseDetailSideEffect {

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailContract.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailContract.kt
@@ -6,7 +6,6 @@ data class PoseDetailState(
     val isLoading: Boolean = false,
     val poses: List<Pose> = emptyList(),
     val currentPage: Int = 0,
-    val committedBookmarks: Map<Long, Boolean> = emptyMap(),
 ) {
     val currentIndex: Int get() = if (poses.isEmpty()) 0 else currentPage.coerceIn(0, poses.lastIndex)
     val pose: Pose get() = poses.getOrElse(currentIndex) { Pose() }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailScreen.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailScreen.kt
@@ -3,27 +3,29 @@ package com.neki.android.feature.pose.impl.detail
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil3.compose.AsyncImage
-import net.engawapg.lib.zoomable.rememberZoomState
-import net.engawapg.lib.zoomable.zoomable
 import com.neki.android.core.designsystem.DevicePreview
 import com.neki.android.core.designsystem.topbar.BackTitleTopBar
 import com.neki.android.core.designsystem.ui.theme.NekiTheme
 import com.neki.android.core.model.Pose
 import com.neki.android.core.navigation.result.LocalResultEventBus
+import com.neki.android.core.ui.component.LoadingDialog
 import com.neki.android.core.ui.compose.collectWithLifecycle
 import com.neki.android.core.ui.toast.NekiToast
 import com.neki.android.feature.pose.api.PoseResult
 import com.neki.android.feature.pose.impl.detail.component.PoseActionBar
+import com.neki.android.feature.pose.impl.detail.component.PoseDetailImageItem
 
 @Composable
 internal fun PoseDetailRoute(
@@ -34,6 +36,15 @@ internal fun PoseDetailRoute(
     val context = LocalContext.current
     val nekiToast = remember { NekiToast(context) }
     val resultEventBus = LocalResultEventBus.current
+    val pagerState = rememberPagerState(initialPage = uiState.currentPage) {
+        uiState.poses.size.coerceAtLeast(1)
+    }
+
+    LaunchedEffect(pagerState) {
+        snapshotFlow { pagerState.settledPage }.collect { page ->
+            viewModel.store.onIntent(PoseDetailIntent.PageChanged(page))
+        }
+    }
 
     viewModel.store.sideEffects.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
@@ -54,6 +65,7 @@ internal fun PoseDetailRoute(
     PoseDetailScreen(
         uiState = uiState,
         onIntent = viewModel.store::onIntent,
+        pagerState = pagerState,
     )
 }
 
@@ -61,6 +73,7 @@ internal fun PoseDetailRoute(
 internal fun PoseDetailScreen(
     uiState: PoseDetailState = PoseDetailState(),
     onIntent: (PoseDetailIntent) -> Unit = {},
+    pagerState: PagerState = rememberPagerState { uiState.poses.size.coerceAtLeast(1) },
 ) {
     Column(
         modifier = Modifier.fillMaxSize(),
@@ -74,22 +87,27 @@ internal fun PoseDetailScreen(
                 .weight(1f)
                 .clipToBounds(),
         ) {
-            val zoomState = rememberZoomState()
-            AsyncImage(
-                model = uiState.pose.poseImageUrl,
-                contentDescription = null,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .zoomable(zoomState),
-                contentScale = ContentScale.Fit,
-                alignment = Alignment.Center,
-                onSuccess = { state -> zoomState.setContentSize(state.painter.intrinsicSize) },
-            )
+            HorizontalPager(
+                modifier = Modifier.fillMaxSize(),
+                state = pagerState,
+                beyondViewportPageCount = 1,
+            ) { page ->
+                val index = if (uiState.poses.isEmpty()) 0 else page.coerceIn(0, uiState.poses.lastIndex)
+                val pose = uiState.poses.getOrNull(index)
+
+                PoseDetailImageItem(
+                    imageUrl = pose?.poseImageUrl,
+                )
+            }
         }
         PoseActionBar(
             isBookmarked = uiState.pose.isBookmarked,
             onClickBookmark = { onIntent(PoseDetailIntent.ClickBookmarkIcon) },
         )
+    }
+
+    if (uiState.isLoading) {
+        LoadingDialog()
     }
 }
 
@@ -99,10 +117,12 @@ private fun PoseDetailScreenPreview() {
     NekiTheme {
         PoseDetailScreen(
             uiState = PoseDetailState(
-                pose = Pose(
-                    id = 1,
-                    poseImageUrl = "https://picsum.photos/400/600",
-                    isBookmarked = false,
+                poses = listOf(
+                    Pose(
+                        id = 1,
+                        poseImageUrl = "https://picsum.photos/400/600",
+                        isBookmarked = false,
+                    ),
                 ),
             ),
         )
@@ -115,10 +135,12 @@ private fun PoseDetailScreenBookmarkedPreview() {
     NekiTheme {
         PoseDetailScreen(
             uiState = PoseDetailState(
-                pose = Pose(
-                    id = 1,
-                    poseImageUrl = "https://picsum.photos/400/600",
-                    isBookmarked = true,
+                poses = listOf(
+                    Pose(
+                        id = 1,
+                        poseImageUrl = "https://picsum.photos/400/600",
+                        isBookmarked = true,
+                    ),
                 ),
             ),
         )

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailViewModel.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailViewModel.kt
@@ -30,6 +30,7 @@ class PoseDetailViewModel @AssistedInject constructor(
 ) : ViewModel() {
 
     private val bookmarkRequests = MutableSharedFlow<Pair<Long, Boolean>>(extraBufferCapacity = 64)
+    private val committedBookmarks = key.poses.associate { it.id to it.isBookmarked }.toMutableMap()
     private var hasNext: Boolean = key.hasNext
     private var nextPage: Int = key.poses.size / PAGE_SIZE
     private var isLoadingMore: Boolean = false
@@ -44,7 +45,6 @@ class PoseDetailViewModel @AssistedInject constructor(
             initialState = PoseDetailState(
                 poses = key.poses,
                 currentPage = key.initialIndex,
-                committedBookmarks = key.poses.associate { it.id to it.isBookmarked },
             ),
             onIntent = ::onIntent,
         )
@@ -55,7 +55,7 @@ class PoseDetailViewModel @AssistedInject constructor(
             bookmarkRequests
                 .debounce(500)
                 .collect { (poseId, newBookmark) ->
-                    val committedBookmark = store.uiState.value.committedBookmarks[poseId] ?: return@collect
+                    val committedBookmark = committedBookmarks[poseId] ?: return@collect
                     if (committedBookmark != newBookmark) {
                         poseRepository.updateBookmark(poseId, newBookmark)
                             .onSuccess {
@@ -90,7 +90,7 @@ class PoseDetailViewModel @AssistedInject constructor(
             }
             PoseDetailIntent.ClickBookmarkIcon -> handleBookmarkToggle(state, reduce, postSideEffect)
             is PoseDetailIntent.BookmarkCommitted -> {
-                reduce { copy(committedBookmarks = committedBookmarks + (intent.poseId to intent.newBookmark)) }
+                committedBookmarks[intent.poseId] = intent.newBookmark
             }
             is PoseDetailIntent.RevertBookmark -> {
                 reduce {
@@ -130,11 +130,11 @@ class PoseDetailViewModel @AssistedInject constructor(
         viewModelScope.launch {
             poseRepository.getPose(poseId = key.poseId)
                 .onSuccess { data ->
+                    committedBookmarks[data.id] = data.isBookmarked
                     reduce {
                         copy(
                             poses = listOf(data),
                             currentPage = 0,
-                            committedBookmarks = mapOf(data.id to data.isBookmarked),
                         )
                     }
                 }
@@ -179,11 +179,11 @@ class PoseDetailViewModel @AssistedInject constructor(
                         reduce {
                             copy(
                                 poses = poses + page.poses,
-                                committedBookmarks = committedBookmarks + page.poses.associate { it.id to it.isBookmarked },
                             )
                         }
                         hasNext = page.hasNext
                         nextPage++
+                        page.poses.forEach { committedBookmarks[it.id] = it.isBookmarked }
                     }
                     .onFailure { e ->
                         Timber.e(e, "loadMorePoses failed")
@@ -199,7 +199,7 @@ class PoseDetailViewModel @AssistedInject constructor(
 
         val state = store.uiState.value
         state.poses.forEach { pose ->
-            val committedBookmark = state.committedBookmarks[pose.id]
+            val committedBookmark = committedBookmarks[pose.id]
             if (committedBookmark != null && pose.isBookmarked != committedBookmark) {
                 applicationScope.launch {
                     poseRepository.updateBookmark(pose.id, pose.isBookmarked)

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailViewModel.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/PoseDetailViewModel.kt
@@ -8,6 +8,7 @@ import com.neki.android.core.common.coroutine.di.ApplicationScope
 import com.neki.android.core.dataapi.repository.PoseRepository
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
+import com.neki.android.feature.pose.api.PoseNavKey
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -22,22 +23,29 @@ import timber.log.Timber
 @OptIn(FlowPreview::class)
 @HiltViewModel(assistedFactory = PoseDetailViewModel.Factory::class)
 class PoseDetailViewModel @AssistedInject constructor(
-    @Assisted private val id: Long,
+    @param:Assisted private val key: PoseNavKey.PoseDetail,
     private val poseRepository: PoseRepository,
-    @ApplicationScope private val applicationScope: CoroutineScope,
+    @param:ApplicationScope private val applicationScope: CoroutineScope,
     private val analyticsLogger: AnalyticsLogger,
 ) : ViewModel() {
 
-    private val bookmarkRequests = MutableSharedFlow<Boolean>(extraBufferCapacity = 64)
+    private val bookmarkRequests = MutableSharedFlow<Pair<Long, Boolean>>(extraBufferCapacity = 64)
+    private var hasNext: Boolean = key.hasNext
+    private var nextPage: Int = key.poses.size / PAGE_SIZE
+    private var isLoadingMore: Boolean = false
 
     @AssistedFactory
     interface Factory {
-        fun create(id: Long): PoseDetailViewModel
+        fun create(key: PoseNavKey.PoseDetail): PoseDetailViewModel
     }
 
     val store: MviIntentStore<PoseDetailState, PoseDetailIntent, PoseDetailSideEffect> =
         mviIntentStore(
-            initialState = PoseDetailState(),
+            initialState = PoseDetailState(
+                poses = key.poses,
+                currentPage = key.initialIndex,
+                committedBookmarks = key.poses.associate { it.id to it.isBookmarked },
+            ),
             onIntent = ::onIntent,
         )
 
@@ -46,17 +54,17 @@ class PoseDetailViewModel @AssistedInject constructor(
         viewModelScope.launch {
             bookmarkRequests
                 .debounce(500)
-                .collect { newBookmark ->
-                    val committedBookmark = store.uiState.value.committedBookmark
+                .collect { (poseId, newBookmark) ->
+                    val committedBookmark = store.uiState.value.committedBookmarks[poseId] ?: return@collect
                     if (committedBookmark != newBookmark) {
-                        poseRepository.updateBookmark(id, newBookmark)
+                        poseRepository.updateBookmark(poseId, newBookmark)
                             .onSuccess {
                                 Timber.d("updateBookmark success")
-                                store.onIntent(PoseDetailIntent.BookmarkCommitted(newBookmark))
+                                store.onIntent(PoseDetailIntent.BookmarkCommitted(poseId, newBookmark))
                             }
                             .onFailure { e ->
                                 Timber.e(e, "updateBookmark failed")
-                                store.onIntent(PoseDetailIntent.RevertBookmark(committedBookmark))
+                                store.onIntent(PoseDetailIntent.RevertBookmark(poseId, committedBookmark))
                             }
                     }
                 }
@@ -70,15 +78,29 @@ class PoseDetailViewModel @AssistedInject constructor(
         postSideEffect: (PoseDetailSideEffect) -> Unit,
     ) {
         when (intent) {
-            PoseDetailIntent.EnterPoseDetailScreen -> fetchPoseData(reduce)
+            PoseDetailIntent.EnterPoseDetailScreen -> {
+                if (state.poses.isEmpty()) {
+                    fetchPoseData(reduce)
+                }
+            }
             PoseDetailIntent.ClickBackIcon -> postSideEffect(PoseDetailSideEffect.NavigateBack)
+            is PoseDetailIntent.PageChanged -> {
+                reduce { copy(currentPage = intent.page) }
+                preloadIfNeeded(reduce)
+            }
             PoseDetailIntent.ClickBookmarkIcon -> handleBookmarkToggle(state, reduce, postSideEffect)
             is PoseDetailIntent.BookmarkCommitted -> {
-                reduce { copy(committedBookmark = intent.newBookmark) }
+                reduce { copy(committedBookmarks = committedBookmarks + (intent.poseId to intent.newBookmark)) }
             }
             is PoseDetailIntent.RevertBookmark -> {
-                reduce { copy(pose = pose.copy(isBookmarked = intent.originalBookmark)) }
-                postSideEffect(PoseDetailSideEffect.NotifyBookmarkChanged(id, intent.originalBookmark))
+                reduce {
+                    copy(
+                        poses = poses.map { pose ->
+                            if (pose.id == intent.poseId) pose.copy(isBookmarked = intent.originalBookmark) else pose
+                        },
+                    )
+                }
+                postSideEffect(PoseDetailSideEffect.NotifyBookmarkChanged(intent.poseId, intent.originalBookmark))
             }
         }
     }
@@ -89,17 +111,32 @@ class PoseDetailViewModel @AssistedInject constructor(
         postSideEffect: (PoseDetailSideEffect) -> Unit,
     ) {
         analyticsLogger.log(PoseAnalyticsEvent.PoseBookmark)
-        val newBookmarkStatus = !state.pose.isBookmarked
-        viewModelScope.launch { bookmarkRequests.emit(newBookmarkStatus) }
-        reduce { copy(pose = pose.copy(isBookmarked = newBookmarkStatus)) }
-        postSideEffect(PoseDetailSideEffect.NotifyBookmarkChanged(id, newBookmarkStatus))
+        val currentPose = state.pose
+        if (currentPose.id == 0L) return
+
+        val newBookmarkStatus = !currentPose.isBookmarked
+        viewModelScope.launch { bookmarkRequests.emit(currentPose.id to newBookmarkStatus) }
+        reduce {
+            copy(
+                poses = poses.map { pose ->
+                    if (pose.id == currentPose.id) pose.copy(isBookmarked = newBookmarkStatus) else pose
+                },
+            )
+        }
+        postSideEffect(PoseDetailSideEffect.NotifyBookmarkChanged(currentPose.id, newBookmarkStatus))
     }
 
     private fun fetchPoseData(reduce: (PoseDetailState.() -> PoseDetailState) -> Unit) {
         viewModelScope.launch {
-            poseRepository.getPose(poseId = id)
+            poseRepository.getPose(poseId = key.poseId)
                 .onSuccess { data ->
-                    reduce { copy(pose = data, committedBookmark = data.isBookmarked) }
+                    reduce {
+                        copy(
+                            poses = listOf(data),
+                            currentPage = 0,
+                            committedBookmarks = mapOf(data.id to data.isBookmarked),
+                        )
+                    }
                 }
                 .onFailure { e ->
                     Timber.e(e)
@@ -107,16 +144,72 @@ class PoseDetailViewModel @AssistedInject constructor(
         }
     }
 
+    private fun preloadIfNeeded(
+        reduce: (PoseDetailState.() -> PoseDetailState) -> Unit,
+    ) {
+        val latestState = store.uiState.value
+        if (latestState.currentIndex >= latestState.poses.size - PRELOAD_THRESHOLD && hasNext && !isLoadingMore) {
+            loadMorePoses(reduce)
+        }
+    }
+
+    private fun loadMorePoses(
+        reduce: (PoseDetailState.() -> PoseDetailState) -> Unit,
+    ) {
+        isLoadingMore = true
+        viewModelScope.launch {
+            try {
+                val result = if (key.isBookmarkOnly) {
+                    poseRepository.getBookmarkedPosesPage(
+                        page = nextPage,
+                        size = PAGE_SIZE,
+                        sortOrder = key.sortOrder,
+                    )
+                } else {
+                    poseRepository.getPosesPage(
+                        headCount = key.headCount,
+                        page = nextPage,
+                        size = PAGE_SIZE,
+                        sortOrder = key.sortOrder,
+                    )
+                }
+
+                result
+                    .onSuccess { page ->
+                        reduce {
+                            copy(
+                                poses = poses + page.poses,
+                                committedBookmarks = committedBookmarks + page.poses.associate { it.id to it.isBookmarked },
+                            )
+                        }
+                        hasNext = page.hasNext
+                        nextPage++
+                    }
+                    .onFailure { e ->
+                        Timber.e(e, "loadMorePoses failed")
+                    }
+            } finally {
+                isLoadingMore = false
+            }
+        }
+    }
+
     override fun onCleared() {
         super.onCleared()
 
-        val currentBookmark = store.uiState.value.pose.isBookmarked
-        val committedBookmark = store.uiState.value.committedBookmark
-
-        if (currentBookmark != committedBookmark) {
-            applicationScope.launch {
-                poseRepository.updateBookmark(id, currentBookmark)
+        val state = store.uiState.value
+        state.poses.forEach { pose ->
+            val committedBookmark = state.committedBookmarks[pose.id]
+            if (committedBookmark != null && pose.isBookmarked != committedBookmark) {
+                applicationScope.launch {
+                    poseRepository.updateBookmark(pose.id, pose.isBookmarked)
+                }
             }
         }
+    }
+
+    companion object {
+        private const val PAGE_SIZE = 5
+        private const val PRELOAD_THRESHOLD = 5
     }
 }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/component/PoseDetailImageItem.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/detail/component/PoseDetailImageItem.kt
@@ -1,0 +1,35 @@
+package com.neki.android.feature.pose.impl.detail.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import coil3.compose.AsyncImage
+import net.engawapg.lib.zoomable.ScrollGesturePropagation
+import net.engawapg.lib.zoomable.rememberZoomState
+import net.engawapg.lib.zoomable.zoomable
+
+@Composable
+internal fun PoseDetailImageItem(
+    imageUrl: String?,
+) {
+    val zoomState = rememberZoomState()
+
+    Box(
+        modifier = Modifier.fillMaxSize(),
+    ) {
+        AsyncImage(
+            modifier = Modifier
+                .fillMaxSize()
+                .zoomable(
+                    zoomState = zoomState,
+                    scrollGesturePropagation = ScrollGesturePropagation.ContentEdge,
+                ),
+            model = imageUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Fit,
+            onSuccess = { state -> zoomState.setContentSize(state.painter.intrinsicSize) },
+        )
+    }
+}

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/main/PoseContract.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/main/PoseContract.kt
@@ -2,6 +2,7 @@ package com.neki.android.feature.pose.impl.main
 
 import com.neki.android.core.model.PeopleCount
 import com.neki.android.core.model.Pose
+import com.neki.android.feature.pose.api.PoseNavKey
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -23,7 +24,7 @@ sealed interface PoseIntent {
     data object DismissPeopleCountBottomSheet : PoseIntent
     data object DismissRandomPosePeopleCountBottomSheet : PoseIntent
     data object ClickBookmarkChip : PoseIntent
-    data class ClickPoseItem(val item: Pose) : PoseIntent
+    data class ClickPoseItem(val item: Pose, val index: Int) : PoseIntent
     data class ClickPeopleCountSheetItem(val peopleCount: PeopleCount) : PoseIntent
     data object ClickRandomPoseRecommendation : PoseIntent
     data class ClickRandomPosePeopleCountSheetItem(val peopleCount: PeopleCount) : PoseIntent
@@ -36,7 +37,7 @@ sealed interface PoseEffect {
     data object NavigateToNotification : PoseEffect
     data object NavigateToQRScan : PoseEffect
     data class NavigateToRandomPose(val peopleCount: PeopleCount) : PoseEffect
-    data class NavigateToPoseDetail(val poseId: Long) : PoseEffect
+    data class NavigateToPoseDetail(val poseDetail: PoseNavKey.PoseDetail) : PoseEffect
     data class ShowToast(val message: String) : PoseEffect
     data object ScrollToTop : PoseEffect
 }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/main/PoseScreen.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/main/PoseScreen.kt
@@ -31,6 +31,7 @@ import com.neki.android.core.model.PeopleCount
 import com.neki.android.core.model.Pose
 import com.neki.android.core.ui.compose.collectWithLifecycle
 import com.neki.android.feature.pose.impl.const.PoseConst.POSE_LAYOUT_DEFAULT_TOP_PADDING
+import com.neki.android.feature.pose.api.PoseNavKey
 import com.neki.android.feature.pose.impl.main.component.PoseFilterBar
 import com.neki.android.feature.pose.impl.main.component.PeopleCountBottomSheet
 import com.neki.android.core.ui.component.LoadingDialog
@@ -46,7 +47,7 @@ import kotlinx.coroutines.launch
 @Composable
 internal fun PoseRoute(
     viewModel: PoseViewModel = hiltViewModel(),
-    navigateToPoseDetail: (Long) -> Unit,
+    navigateToPoseDetail: (PoseNavKey.PoseDetail) -> Unit,
     navigateToRandomPose: (PeopleCount) -> Unit,
     navigateToNotification: () -> Unit,
     navigateToQRScan: () -> Unit,
@@ -67,7 +68,14 @@ internal fun PoseRoute(
             PoseEffect.NavigateToNotification -> navigateToNotification()
             PoseEffect.NavigateToQRScan -> navigateToQRScan()
             is PoseEffect.NavigateToRandomPose -> navigateToRandomPose(sideEffect.peopleCount)
-            is PoseEffect.NavigateToPoseDetail -> navigateToPoseDetail(sideEffect.poseId)
+            is PoseEffect.NavigateToPoseDetail -> {
+                navigateToPoseDetail(
+                    sideEffect.poseDetail.copy(
+                        poses = posePagingItems.itemSnapshotList.items,
+                        hasNext = !posePagingItems.loadState.append.endOfPaginationReached,
+                    ),
+                )
+            }
             is PoseEffect.ShowToast -> nekiToast.showToast(sideEffect.message)
             PoseEffect.ScrollToTop -> coroutineScope.launch {
                 snapshotFlow { posePagingItems.loadState.refresh }
@@ -111,7 +119,7 @@ fun PoseScreen(
 //            onClickAlarmIcon = { onIntent(PoseIntent.ClickAlarmIcon) },
             onClickPeopleCount = { onIntent(PoseIntent.ClickPeopleCountChip) },
             onClickBookmark = { onIntent(PoseIntent.ClickBookmarkChip) },
-            onClickPoseItem = { onIntent(PoseIntent.ClickPoseItem(it)) },
+            onClickPoseItem = { pose, index -> onIntent(PoseIntent.ClickPoseItem(pose, index)) },
             onClickBookmarkIcon = { onIntent(PoseIntent.ClickBookmarkIcon(it)) },
         )
 
@@ -155,7 +163,7 @@ fun PoseContent(
     onClickQRCodeIcon: () -> Unit = {},
     onClickPeopleCount: () -> Unit = {},
     onClickBookmark: () -> Unit = {},
-    onClickPoseItem: (Pose) -> Unit = {},
+    onClickPoseItem: (Pose, Int) -> Unit = { _, _ -> },
     onClickBookmarkIcon: (Pose) -> Unit = {},
 ) {
     val density = LocalDensity.current

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/main/PoseViewModel.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/main/PoseViewModel.kt
@@ -14,6 +14,7 @@ import com.neki.android.core.model.Pose
 import com.neki.android.core.model.SortOrder
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
+import com.neki.android.feature.pose.api.PoseNavKey
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -108,7 +109,17 @@ internal class PoseViewModel @Inject constructor(
             }
 
             is PoseIntent.ClickPoseItem -> {
-                postSideEffect(PoseEffect.NavigateToPoseDetail(intent.item.id))
+                postSideEffect(
+                    PoseEffect.NavigateToPoseDetail(
+                        PoseNavKey.PoseDetail(
+                            poseId = intent.item.id,
+                            initialIndex = intent.index,
+                            headCount = state.selectedPeopleCount,
+                            sortOrder = SortOrder.DESC,
+                            isBookmarkOnly = state.isShowBookmarkedPose,
+                        ),
+                    ),
+                )
             }
 
             PoseIntent.ClickRandomPoseRecommendation -> reduce { copy(isShowRandomPosePeopleCountBottomSheet = true) }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/main/component/PoseListContent.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/main/component/PoseListContent.kt
@@ -10,12 +10,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridState
 import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.lazy.staggeredgrid.rememberLazyStaggeredGridState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -26,6 +29,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemKey
 import coil3.compose.AsyncImage
@@ -45,7 +49,7 @@ internal fun PoseListContent(
     modifier: Modifier = Modifier,
     posePagingItems: LazyPagingItems<Pose>,
     state: LazyStaggeredGridState = rememberLazyStaggeredGridState(),
-    onClickItem: (Pose) -> Unit = {},
+    onClickItem: (Pose, Int) -> Unit = { _, _ -> },
     onClickBookmark: (Pose) -> Unit = {},
 ) {
     LazyVerticalStaggeredGrid(
@@ -65,9 +69,24 @@ internal fun PoseListContent(
             posePagingItems[index]?.let { pose ->
                 PoseItem(
                     pose = pose,
-                    onClickItem = onClickItem,
+                    onClickItem = { onClickItem(pose, index) },
                     onClickBookmark = onClickBookmark,
                 )
+            }
+        }
+
+        if (posePagingItems.loadState.append is LoadState.Loading) {
+            item(span = StaggeredGridItemSpan.FullLine) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(
+                        color = NekiTheme.colorScheme.primary500,
+                    )
+                }
             }
         }
     }
@@ -80,7 +99,12 @@ private fun PoseItem(
     onClickItem: (Pose) -> Unit = {},
     onClickBookmark: (Pose) -> Unit = {},
 ) {
-    var aspectRatio by rememberSaveable { mutableFloatStateOf(0f) }
+    val hasSize = pose.width != null && pose.height != null
+    var aspectRatio by if (hasSize) {
+        remember { mutableFloatStateOf(pose.width!! / pose.height!!.toFloat()) }
+    } else {
+        rememberSaveable { mutableFloatStateOf(0f) }
+    }
 
     Box(
         modifier = modifier
@@ -98,9 +122,11 @@ private fun PoseItem(
             contentDescription = null,
             contentScale = ContentScale.FillWidth,
             onSuccess = { state ->
-                val size = state.painter.intrinsicSize
-                if (size.width > 0f && size.height > 0f) {
-                    aspectRatio = size.width / size.height
+                if (!hasSize) {
+                    val size = state.painter.intrinsicSize
+                    if (size.width > 0f && size.height > 0f) {
+                        aspectRatio = size.width / size.height
+                    }
                 }
             },
         )

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/navigation/PoseEntryProvider.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/navigation/PoseEntryProvider.kt
@@ -89,7 +89,6 @@ private fun EntryProviderScope<NavKey>.poseEntry(navigator: MainNavigator) {
         RandomPoseRoute(
             viewModel = viewModel,
             navigateBack = navigator::goBack,
-            navigateToPoseDetail = navigator::navigateToPoseDetail,
         )
     }
 }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/navigation/PoseEntryProvider.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/navigation/PoseEntryProvider.kt
@@ -63,7 +63,7 @@ private fun EntryProviderScope<NavKey>.poseEntry(navigator: MainNavigator) {
         PoseDetailRoute(
             viewModel = hiltViewModel<PoseDetailViewModel, PoseDetailViewModel.Factory>(
                 creationCallback = { factory ->
-                    factory.create(key.poseId)
+                    factory.create(key)
                 },
             ),
             navigateBack = navigator::goBack,

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseContract.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseContract.kt
@@ -30,7 +30,6 @@ sealed interface RandomPoseIntent {
 
     // 기본화면
     data object ClickCloseIcon : RandomPoseIntent
-    data object ClickGoToDetailIcon : RandomPoseIntent
     data object ClickBookmarkIcon : RandomPoseIntent
     data object ClickLeftSwipe : RandomPoseIntent
     data object ClickRightSwipe : RandomPoseIntent
@@ -40,7 +39,6 @@ sealed interface RandomPoseIntent {
 
 sealed interface RandomPoseEffect {
     data object NavigateBack : RandomPoseEffect
-    data class NavigateToDetail(val poseId: Long) : RandomPoseEffect
     data class ShowToast(val message: String) : RandomPoseEffect
     data class AnimateToPage(val index: Int) : RandomPoseEffect
 }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseScreen.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseScreen.kt
@@ -37,7 +37,6 @@ import dev.chrisbanes.haze.rememberHazeState
 internal fun RandomPoseRoute(
     viewModel: RandomPoseViewModel = hiltViewModel(),
     navigateBack: () -> Unit,
-    navigateToPoseDetail: (Long) -> Unit,
 ) {
     val uiState by viewModel.store.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
@@ -54,7 +53,6 @@ internal fun RandomPoseRoute(
     viewModel.store.sideEffects.collectWithLifecycle { sideEffect ->
         when (sideEffect) {
             RandomPoseEffect.NavigateBack -> navigateBack()
-            is RandomPoseEffect.NavigateToDetail -> navigateToPoseDetail(sideEffect.poseId)
             is RandomPoseEffect.ShowToast -> nekiToast.showToast(sideEffect.message)
             is RandomPoseEffect.AnimateToPage -> coroutineScope.launch {
                 pagerState.animateScrollToPage(
@@ -119,7 +117,6 @@ internal fun RandomPoseScreen(
                     modifier = Modifier.fillMaxWidth(),
                     isBookmarked = pose.isBookmarked,
                     onClickClose = { onIntent(RandomPoseIntent.ClickCloseIcon) },
-                    onClickGoToDetail = { onIntent(RandomPoseIntent.ClickGoToDetailIcon) },
                     onClickBookmark = { onIntent(RandomPoseIntent.ClickBookmarkIcon) },
                 )
             }

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseViewModel.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/RandomPoseViewModel.kt
@@ -85,11 +85,6 @@ internal class RandomPoseViewModel @AssistedInject constructor(
 
             // 기본화면
             RandomPoseIntent.ClickCloseIcon -> postSideEffect(RandomPoseEffect.NavigateBack)
-            RandomPoseIntent.ClickGoToDetailIcon -> {
-                state.currentPose?.let { pose ->
-                    postSideEffect(RandomPoseEffect.NavigateToDetail(pose.id))
-                }
-            }
 
             RandomPoseIntent.ClickBookmarkIcon -> {
                 analyticsLogger.log(PoseAnalyticsEvent.PoseBookmark)

--- a/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/component/RandomPoseFloatingBar.kt
+++ b/feature/pose/impl/src/main/java/com/neki/android/feature/pose/impl/random/component/RandomPoseFloatingBar.kt
@@ -32,7 +32,6 @@ internal fun RandomPoseFloatingBarContent(
     modifier: Modifier = Modifier,
     isBookmarked: Boolean = false,
     onClickClose: () -> Unit = {},
-    onClickGoToDetail: () -> Unit = {},
     onClickBookmark: () -> Unit = {},
 ) {
     Box(
@@ -47,7 +46,6 @@ internal fun RandomPoseFloatingBarContent(
                 .padding(top = 38.dp, bottom = 34.dp),
             isBookmarked = isBookmarked,
             onClickClose = onClickClose,
-            onClickGoToDetail = onClickGoToDetail,
             onClickBookmark = onClickBookmark,
         )
     }
@@ -76,7 +74,6 @@ private fun RandomPoseFloatingBar(
     modifier: Modifier = Modifier,
     isBookmarked: Boolean = false,
     onClickClose: () -> Unit = {},
-    onClickGoToDetail: () -> Unit = {},
     onClickBookmark: () -> Unit = {},
 ) {
     Row(
@@ -117,18 +114,6 @@ private fun RandomPoseFloatingBar(
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            RandomPoseButton(
-                onClick = onClickGoToDetail,
-                backgroundColor = NekiTheme.colorScheme.primary400,
-            ) {
-                Icon(
-                    modifier = Modifier.size(24.dp),
-                    imageVector = ImageVector.vectorResource(R.drawable.icon_arrow_top_right),
-                    contentDescription = "상세 보기",
-                    tint = NekiTheme.colorScheme.white,
-                )
-            }
-
             RandomPoseButton(
                 onClick = onClickBookmark,
                 backgroundColor = NekiTheme.colorScheme.primary400,


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #210

## 📙 작업 설명
- 포즈 상세에서 사진 상세과 같은 방식의 좌우 pager 스와이프를 지원합니다.
- 포즈 목록 snapshot, 선택 index, 필터 조건, hasNext를 상세로 전달하고 상세에서 preload 및 추가 로드를 처리합니다.
- 포즈 목록 API의 nullable width/height를 모델에 반영하고, 값이 있을 때 이미지 영역 비율을 먼저 잡아 레이아웃 시프트를 줄입니다.
- 랜덤 포즈 화면의 포즈 상세 이동 버튼과 관련 navigation/effect를 제거합니다.

## 🧪 테스트 내역 (선택)
- [x] 주요 기능 정상 동작 확인
- [ ] 브라우저/기기에서 동작 확인
- [x] 엣지 케이스 테스트 완료
- [x] 기존 기능 영향 없음

검증 명령:
```bash
./gradlew :core:model:compileKotlin :core:data-api:compileDebugKotlin :core:data:compileDebugKotlin :feature:pose:api:compileDebugKotlin :feature:pose:impl:compileDebugKotlin :core:model:detekt :core:data-api:detekt :core:data:detekt :feature:pose:api:detekt :feature:pose:impl:detekt
```

## 📸 스크린샷 또는 시연 영상 (선택)
<!-- UI 변경사항이 있다면 이미지나 GIF를 첨부해주세요 -->
|기능|미리보기|기능|미리보기|
|:--:|:--:|:--:|:--:|
| - | - | - | - |

## 💬 추가 설명 or 리뷰 포인트 (선택)
- 사진 상세의 list snapshot 기반 pager/preload 구조를 포즈 상세에도 맞춰 적용했습니다.
- 포즈 width/height는 nullable로 처리하며, 값이 없으면 기존처럼 이미지 로드 성공 후 intrinsic size를 사용합니다.
- 상세 추가 로드 시 기존 snapshot과 추가 응답 간 동일 항목 중복 가능성은 사진/포즈 공통 follow-up 이슈로 분리했습니다: #214
- 요청에 따라 테스트 코드는 PR 커밋에 포함하지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 포즈 목록에 페이지네이션 기반 로딩 추가
  * 상세 화면에서 여러 포즈를 슬라이드로 탐색(페이징 연동)

* **개선사항**
  * 다음 페이지 여부를 hasNext 기준으로 더 안정적으로 처리
  * 상세 화면에서 포즈 단위 북마크 상태 반영 및 프리로드 개선
  * 상세 진입 시 선택 위치/정렬 조건 유지

* **UI 변경**
  * 랜덤 포즈의 “상세 보기” 버튼 제거
  * 포즈 이미지 가로/세로 크기 정보 반영하여 비율 표시 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->