### PR TITLE
[feat] #211 FCM 푸시 알림 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,7 @@ dependencies {
 
     implementation(platform(libs.firebase.bom))
     implementation(libs.firebase.crashlytics)
+    implementation(libs.firebase.messaging)
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation3.ui)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,6 +53,14 @@
             </intent-filter>
         </activity>
 
+        <service
+            android:name=".NekiFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
             android:theme="@style/OssLicenses.Theme.OptOutEdgeToEdgeEnforcement" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -53,6 +53,10 @@
             </intent-filter>
         </activity>
 
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="neki_default_channel_id" />
+
         <service
             android:name=".NekiFirebaseMessagingService"
             android:exported="false">

--- a/app/src/main/java/com/neki/android/app/NekiApplication.kt
+++ b/app/src/main/java/com/neki/android/app/NekiApplication.kt
@@ -1,6 +1,9 @@
 package com.neki.android.app
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
 import com.kakao.sdk.common.KakaoSdk
 import com.naver.maps.map.NaverMapSdk
 import dagger.hilt.android.HiltAndroidApp
@@ -25,5 +28,16 @@ class NekiApplication : Application() {
 
         NaverMapSdk.getInstance(this).client = NaverMapSdk.NcpKeyClient(BuildConfig.NAVER_MAP_CLIENT_ID)
         KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)
+        createNotificationChannel()
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            NekiFirebaseMessagingService.CHANNEL_ID,
+            NekiFirebaseMessagingService.CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_HIGH,
+        )
+        val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.createNotificationChannel(channel)
     }
 }

--- a/app/src/main/java/com/neki/android/app/NekiFirebaseMessagingService.kt
+++ b/app/src/main/java/com/neki/android/app/NekiFirebaseMessagingService.kt
@@ -1,0 +1,62 @@
+package com.neki.android.app
+
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import com.neki.android.core.dataapi.repository.NotificationRepository
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class NekiFirebaseMessagingService : FirebaseMessagingService() {
+
+    @Inject lateinit var notificationRepository: NotificationRepository
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+        CoroutineScope(Dispatchers.IO).launch {
+            notificationRepository.savePushToken(token)
+        }
+    }
+
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
+        val title = message.notification?.title ?: return
+        val body = message.notification?.body ?: return
+        showNotification(title, body)
+    }
+
+    private fun showNotification(title: String, body: String) {
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            packageManager.getLaunchIntentForPackage(packageName) ?: Intent(),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setAutoCancel(true)
+            .setContentIntent(pendingIntent)
+            .build()
+
+        notificationManager.notify(System.currentTimeMillis().toInt(), notification)
+    }
+
+    companion object {
+        const val CHANNEL_ID = "neki_default_channel_id"
+        const val CHANNEL_NAME = "Neki-Notification-Channel"
+    }
+}

--- a/app/src/main/java/com/neki/android/app/NekiFirebaseMessagingService.kt
+++ b/app/src/main/java/com/neki/android/app/NekiFirebaseMessagingService.kt
@@ -12,7 +12,6 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/app/src/main/java/com/neki/android/app/NekiFirebaseMessagingService.kt
+++ b/app/src/main/java/com/neki/android/app/NekiFirebaseMessagingService.kt
@@ -47,6 +47,7 @@ class NekiFirebaseMessagingService : FirebaseMessagingService() {
             .setSmallIcon(R.mipmap.ic_launcher)
             .setContentTitle(title)
             .setContentText(body)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(body))
             .setAutoCancel(true)
             .setContentIntent(pendingIntent)
             .build()

--- a/app/src/main/java/com/neki/android/app/main/MainContract.kt
+++ b/app/src/main/java/com/neki/android/app/main/MainContract.kt
@@ -14,6 +14,7 @@ data class MainState(
 )
 
 sealed interface MainIntent {
+    data object EnterMainScreen : MainIntent
     data object ClickAddPhotoFab : MainIntent
     data object DismissAddPhotoBottomSheet : MainIntent
     data object ClickQRScan : MainIntent

--- a/app/src/main/java/com/neki/android/app/main/MainViewModel.kt
+++ b/app/src/main/java/com/neki/android/app/main/MainViewModel.kt
@@ -1,14 +1,18 @@
 package com.neki.android.app.main
 
+import android.content.Context
 import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.neki.android.core.common.permission.NotificationPermissionManager
+import com.neki.android.core.dataapi.repository.NotificationRepository
 import com.neki.android.core.domain.usecase.UploadMultiplePhotoUseCase
 import com.neki.android.core.domain.usecase.UploadSinglePhotoUseCase
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
 import com.neki.android.feature.select_album.api.SelectAlbumAction
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
@@ -17,6 +21,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val notificationRepository: NotificationRepository,
     private val uploadSinglePhotoUseCase: UploadSinglePhotoUseCase,
     private val uploadMultiplePhotoUseCase: UploadMultiplePhotoUseCase,
 ) : ViewModel() {
@@ -27,6 +33,10 @@ class MainViewModel @Inject constructor(
             onIntent = ::onIntent,
         )
 
+    init {
+        store.onIntent(MainIntent.EnterMainScreen)
+    }
+
     private fun onIntent(
         intent: MainIntent,
         state: MainState,
@@ -34,6 +44,7 @@ class MainViewModel @Inject constructor(
         postSideEffect: (MainSideEffect) -> Unit,
     ) {
         when (intent) {
+            MainIntent.EnterMainScreen -> updateNotificationToken()
             MainIntent.ClickAddPhotoFab -> reduce { copy(isShowAddPhotoBottomSheet = true) }
             MainIntent.DismissAddPhotoBottomSheet -> reduce { copy(isShowAddPhotoBottomSheet = false) }
             MainIntent.ClickQRScan -> {
@@ -91,6 +102,15 @@ class MainViewModel @Inject constructor(
                     )
                 }
             }
+        }
+    }
+
+    private fun updateNotificationToken() {
+        viewModelScope.launch {
+            val token = notificationRepository.getPushToken() ?: return@launch
+            val pushAgreed = NotificationPermissionManager.isGrantedNotificationPermission(context)
+            notificationRepository.updateNotification(token, pushAgreed)
+                .onFailure { Timber.e(it, "Failed to update notification token") }
         }
     }
 

--- a/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/AuthRepository.kt
+++ b/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/AuthRepository.kt
@@ -11,6 +11,7 @@ interface AuthRepository {
 
     suspend fun loginWithKakao(idToken: String): Result<Auth>
     suspend fun updateAccessToken(refreshToken: String): Result<Auth>
+    suspend fun logout(): Result<Unit>
     suspend fun withdrawAccount(): Result<Unit>
 
     fun hasCompletedOnboarding(): Flow<Boolean>

--- a/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/NotificationRepository.kt
+++ b/core/data-api/src/main/java/com/neki/android/core/dataapi/repository/NotificationRepository.kt
@@ -1,0 +1,7 @@
+package com.neki.android.core.dataapi.repository
+
+interface NotificationRepository {
+    suspend fun savePushToken(token: String)
+    suspend fun getPushToken(): String?
+    suspend fun updateNotification(deviceToken: String, pushAgreed: Boolean): Result<Unit>
+}

--- a/core/data/src/main/java/com/neki/android/core/data/remote/api/AuthService.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/api/AuthService.kt
@@ -32,6 +32,11 @@ class AuthService @Inject constructor(
         return client.post("/api/auth/refresh") { setBody(requestBody) }.body()
     }
 
+    // 로그아웃
+    suspend fun logout(): BasicNullableResponse<Unit> {
+        return client.post("/api/users/logout").body()
+    }
+
     // 회원 탈퇴
     suspend fun withdrawAccount(): BasicNullableResponse<Unit> {
         return client.delete("/api/users/me").body()

--- a/core/data/src/main/java/com/neki/android/core/data/remote/api/NotificationService.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/api/NotificationService.kt
@@ -1,0 +1,16 @@
+package com.neki.android.core.data.remote.api
+
+import com.neki.android.core.data.remote.model.request.UpdateNotificationRequest
+import com.neki.android.core.data.remote.model.response.BasicNullableResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.patch
+import io.ktor.client.request.setBody
+import javax.inject.Inject
+
+class NotificationService @Inject constructor(
+    private val client: HttpClient,
+) {
+    suspend fun updateNotification(request: UpdateNotificationRequest): BasicNullableResponse<Unit> =
+        client.patch("/api/notifications") { setBody(request) }.body()
+}

--- a/core/data/src/main/java/com/neki/android/core/data/remote/model/request/UpdateNotificationRequest.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/remote/model/request/UpdateNotificationRequest.kt
@@ -1,0 +1,10 @@
+package com.neki.android.core.data.remote.model.request
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UpdateNotificationRequest(
+    @SerialName("deviceToken") val deviceToken: String,
+    @SerialName("pushAgreed") val pushAgreed: Boolean,
+)

--- a/core/data/src/main/java/com/neki/android/core/data/repository/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/di/RepositoryModule.kt
@@ -3,6 +3,7 @@ package com.neki.android.core.data.repository.di
 import com.neki.android.core.data.auth.AuthEventManagerImpl
 import com.neki.android.core.data.repository.impl.AuthRepositoryImpl
 import com.neki.android.core.data.repository.impl.DiscordWebhookRepositoryImpl
+import com.neki.android.core.data.repository.impl.NotificationRepositoryImpl
 import com.neki.android.core.data.repository.impl.MediaUploadRepositoryImpl
 import com.neki.android.core.data.repository.impl.FolderRepositoryImpl
 import com.neki.android.core.data.repository.impl.MapRepositoryImpl
@@ -13,6 +14,7 @@ import com.neki.android.core.data.repository.impl.TokenRepositoryImpl
 import com.neki.android.core.data.repository.impl.UserRepositoryImpl
 import com.neki.android.core.dataapi.auth.AuthEventManager
 import com.neki.android.core.dataapi.repository.DiscordWebhookRepository
+import com.neki.android.core.dataapi.repository.NotificationRepository
 import com.neki.android.core.dataapi.repository.FolderRepository
 import com.neki.android.core.dataapi.repository.AuthRepository
 import com.neki.android.core.dataapi.repository.MediaUploadRepository
@@ -97,4 +99,10 @@ internal interface RepositoryModule {
     fun bindDiscordWebhookRepositoryImpl(
         discordWebhookRepositoryImpl: DiscordWebhookRepositoryImpl,
     ): DiscordWebhookRepository
+
+    @Binds
+    @Singleton
+    fun bindNotificationRepositoryImpl(
+        notificationRepositoryImpl: NotificationRepositoryImpl,
+    ): NotificationRepository
 }

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/AuthRepositoryImpl.kt
@@ -53,6 +53,10 @@ class AuthRepositoryImpl @Inject constructor(
         ).data.toModel()
     }
 
+    override suspend fun logout(): Result<Unit> = runSuspendCatching {
+        authService.logout()
+    }
+
     override suspend fun withdrawAccount(): Result<Unit> = runSuspendCatching {
         authService.withdrawAccount()
     }

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/NotificationRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/NotificationRepositoryImpl.kt
@@ -1,0 +1,43 @@
+package com.neki.android.core.data.repository.impl
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import com.neki.android.core.data.local.di.UserDataStore
+import com.neki.android.core.data.remote.api.NotificationService
+import com.neki.android.core.data.remote.model.request.UpdateNotificationRequest
+import com.neki.android.core.data.util.runSuspendCatching
+import com.neki.android.core.dataapi.repository.NotificationRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+class NotificationRepositoryImpl @Inject constructor(
+    @UserDataStore private val dataStore: DataStore<Preferences>,
+    private val notificationService: NotificationService,
+) : NotificationRepository {
+
+    companion object {
+        private val PUSH_TOKEN = stringPreferencesKey("push_token")
+    }
+
+    override suspend fun savePushToken(token: String) {
+        dataStore.edit { it[PUSH_TOKEN] = token }
+    }
+
+    override suspend fun getPushToken(): String? =
+        dataStore.data.map { it[PUSH_TOKEN] }.first()
+
+    override suspend fun updateNotification(
+        deviceToken: String,
+        pushAgreed: Boolean,
+    ): Result<Unit> = runSuspendCatching {
+        notificationService.updateNotification(
+            UpdateNotificationRequest(
+                deviceToken = deviceToken,
+                pushAgreed = pushAgreed,
+            ),
+        )
+    }
+}

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/TokenRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/TokenRepositoryImpl.kt
@@ -37,11 +37,11 @@ class TokenRepositoryImpl @Inject constructor(
 
     override fun hasTokens(): Flow<Boolean> {
         return dataStore.data.map { preferences ->
-            runCatching {
+            try {
                 val accessToken = preferences[ACCESS_TOKEN]?.let { CryptoManager.decrypt(it) }
                 val refreshToken = preferences[REFRESH_TOKEN]?.let { CryptoManager.decrypt(it) }
                 !accessToken.isNullOrBlank() && !refreshToken.isNullOrBlank()
-            }.getOrElse {
+            } catch (e: Exception) {
                 dataStore.edit { it.remove(ACCESS_TOKEN); it.remove(REFRESH_TOKEN) }
                 false
             }

--- a/core/data/src/main/java/com/neki/android/core/data/repository/impl/TokenRepositoryImpl.kt
+++ b/core/data/src/main/java/com/neki/android/core/data/repository/impl/TokenRepositoryImpl.kt
@@ -37,22 +37,30 @@ class TokenRepositoryImpl @Inject constructor(
 
     override fun hasTokens(): Flow<Boolean> {
         return dataStore.data.map { preferences ->
-            val accessToken = preferences[ACCESS_TOKEN]?.let { CryptoManager.decrypt(it) }
-            val refreshToken = preferences[REFRESH_TOKEN]?.let { CryptoManager.decrypt(it) }
-
-            !accessToken.isNullOrBlank() && !refreshToken.isNullOrBlank()
+            runCatching {
+                val accessToken = preferences[ACCESS_TOKEN]?.let { CryptoManager.decrypt(it) }
+                val refreshToken = preferences[REFRESH_TOKEN]?.let { CryptoManager.decrypt(it) }
+                !accessToken.isNullOrBlank() && !refreshToken.isNullOrBlank()
+            }.getOrElse {
+                dataStore.edit { it.remove(ACCESS_TOKEN); it.remove(REFRESH_TOKEN) }
+                false
+            }
         }
     }
 
     override fun getAccessToken(): Flow<String> {
         return dataStore.data.map { preferences ->
-            preferences[ACCESS_TOKEN]?.let { CryptoManager.decrypt(it) } ?: ""
+            runCatching {
+                preferences[ACCESS_TOKEN]?.let { CryptoManager.decrypt(it) } ?: ""
+            }.getOrElse { "" }
         }
     }
 
     override fun getRefreshToken(): Flow<String> {
         return dataStore.data.map { preferences ->
-            preferences[REFRESH_TOKEN]?.let { CryptoManager.decrypt(it) } ?: ""
+            runCatching {
+                preferences[REFRESH_TOKEN]?.let { CryptoManager.decrypt(it) } ?: ""
+            }.getOrElse { "" }
         }
     }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
@@ -1,12 +1,15 @@
 package com.neki.android.feature.archive.impl.main
 
+import android.content.Context
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.neki.android.core.analytics.event.ArchiveAnalyticsEvent
 import com.neki.android.core.analytics.logger.AnalyticsLogger
 import com.neki.android.core.common.const.TermConst
+import com.neki.android.core.common.permission.NotificationPermissionManager
 import com.neki.android.core.dataapi.repository.FolderRepository
+import com.neki.android.core.dataapi.repository.NotificationRepository
 import com.neki.android.core.dataapi.repository.PhotoRepository
 import com.neki.android.core.dataapi.repository.TermRepository
 import com.neki.android.core.dataapi.repository.UserRepository
@@ -14,6 +17,7 @@ import com.neki.android.core.model.Photo
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -27,10 +31,12 @@ private const val DEFAULT_PHOTOS_SIZE = 20
 
 @HiltViewModel
 class ArchiveMainViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val photoRepository: PhotoRepository,
     private val folderRepository: FolderRepository,
     private val userRepository: UserRepository,
     private val termRepository: TermRepository,
+    private val notificationRepository: NotificationRepository,
     private val analyticsLogger: AnalyticsLogger,
 ) : ViewModel() {
 
@@ -57,7 +63,10 @@ class ArchiveMainViewModel @Inject constructor(
     ) {
         if (intent != ArchiveMainIntent.EnterArchiveMainScreen) reduce { copy(isFirstEntered = false) }
         when (intent) {
-            ArchiveMainIntent.EnterArchiveMainScreen -> fetchInitialData(reduce)
+            ArchiveMainIntent.EnterArchiveMainScreen -> {
+                fetchInitialData(reduce)
+                updateNotificationToken()
+            }
             ArchiveMainIntent.RefreshArchiveMain -> viewModelScope.launch {
                 awaitAll(
                     async { fetchFavoriteSummary(reduce) },
@@ -98,6 +107,15 @@ class ArchiveMainViewModel @Inject constructor(
                 reduce { copy(showMarketingAgreementDialog = false) }
                 agreeMarketingTerm(postSideEffect)
             }
+        }
+    }
+
+    private fun updateNotificationToken() {
+        viewModelScope.launch {
+            val token = notificationRepository.getPushToken() ?: return@launch
+            val pushAgreed = NotificationPermissionManager.isGrantedNotificationPermission(context)
+            notificationRepository.updateNotification(token, pushAgreed)
+                .onFailure { Timber.e(it, "Failed to update notification token") }
         }
     }
 

--- a/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
+++ b/feature/archive/impl/src/main/kotlin/com/neki/android/feature/archive/impl/main/ArchiveMainViewModel.kt
@@ -1,15 +1,12 @@
 package com.neki.android.feature.archive.impl.main
 
-import android.content.Context
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.neki.android.core.analytics.event.ArchiveAnalyticsEvent
 import com.neki.android.core.analytics.logger.AnalyticsLogger
 import com.neki.android.core.common.const.TermConst
-import com.neki.android.core.common.permission.NotificationPermissionManager
 import com.neki.android.core.dataapi.repository.FolderRepository
-import com.neki.android.core.dataapi.repository.NotificationRepository
 import com.neki.android.core.dataapi.repository.PhotoRepository
 import com.neki.android.core.dataapi.repository.TermRepository
 import com.neki.android.core.dataapi.repository.UserRepository
@@ -17,7 +14,6 @@ import com.neki.android.core.model.Photo
 import com.neki.android.core.ui.MviIntentStore
 import com.neki.android.core.ui.mviIntentStore
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
@@ -31,12 +27,10 @@ private const val DEFAULT_PHOTOS_SIZE = 20
 
 @HiltViewModel
 class ArchiveMainViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
     private val photoRepository: PhotoRepository,
     private val folderRepository: FolderRepository,
     private val userRepository: UserRepository,
     private val termRepository: TermRepository,
-    private val notificationRepository: NotificationRepository,
     private val analyticsLogger: AnalyticsLogger,
 ) : ViewModel() {
 
@@ -63,10 +57,7 @@ class ArchiveMainViewModel @Inject constructor(
     ) {
         if (intent != ArchiveMainIntent.EnterArchiveMainScreen) reduce { copy(isFirstEntered = false) }
         when (intent) {
-            ArchiveMainIntent.EnterArchiveMainScreen -> {
-                fetchInitialData(reduce)
-                updateNotificationToken()
-            }
+            ArchiveMainIntent.EnterArchiveMainScreen -> fetchInitialData(reduce)
             ArchiveMainIntent.RefreshArchiveMain -> viewModelScope.launch {
                 awaitAll(
                     async { fetchFavoriteSummary(reduce) },
@@ -107,15 +98,6 @@ class ArchiveMainViewModel @Inject constructor(
                 reduce { copy(showMarketingAgreementDialog = false) }
                 agreeMarketingTerm(postSideEffect)
             }
-        }
-    }
-
-    private fun updateNotificationToken() {
-        viewModelScope.launch {
-            val token = notificationRepository.getPushToken() ?: return@launch
-            val pushAgreed = NotificationPermissionManager.isGrantedNotificationPermission(context)
-            notificationRepository.updateNotification(token, pushAgreed)
-                .onFailure { Timber.e(it, "Failed to update notification token") }
         }
     }
 

--- a/feature/auth/impl/build.gradle.kts
+++ b/feature/auth/impl/build.gradle.kts
@@ -10,4 +10,8 @@ dependencies {
     implementation(libs.androidx.activity.compose)
 
     implementation(projects.feature.auth.api)
+
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.messaging)
+    implementation(libs.kotlinx.coroutines.play.services)
 }

--- a/feature/auth/impl/build.gradle.kts
+++ b/feature/auth/impl/build.gradle.kts
@@ -11,7 +11,4 @@ dependencies {
 
     implementation(projects.feature.auth.api)
 
-    implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.messaging)
-    implementation(libs.kotlinx.coroutines.play.services)
 }

--- a/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/main/MyPageViewModel.kt
+++ b/feature/mypage/impl/src/main/java/com/neki/android/feature/mypage/impl/main/MyPageViewModel.kt
@@ -71,10 +71,7 @@ internal class MyPageViewModel @Inject constructor(
 
             MyPageIntent.ClickLogout -> reduce { copy(isShowLogoutDialog = true) }
             MyPageIntent.DismissLogoutDialog -> reduce { copy(isShowLogoutDialog = false) }
-            MyPageIntent.ConfirmLogout -> {
-                reduce { copy(isShowLogoutDialog = false) }
-                logout(postSideEffect)
-            }
+            MyPageIntent.ConfirmLogout -> logout(reduce, postSideEffect)
 
             MyPageIntent.ClickWithdraw -> reduce { copy(isShowWithdrawDialog = true) }
             MyPageIntent.DismissWithdrawDialog -> reduce { copy(isShowWithdrawDialog = false) }
@@ -152,10 +149,18 @@ internal class MyPageViewModel @Inject constructor(
             }
     }
 
-    private fun logout(postSideEffect: (MyPageEffect) -> Unit) = viewModelScope.launch {
+    private fun logout(
+        reduce: (MyPageState.() -> MyPageState) -> Unit,
+        postSideEffect: (MyPageEffect) -> Unit,
+    ) = viewModelScope.launch {
         analyticsLogger.log(MypageAnalyticsEvent.Logout)
-        tokenRepository.clearTokensWithAuthCache()
-        postSideEffect(MyPageEffect.LogoutWithKakao)
+        authRepository.logout()
+            .onSuccess {
+                reduce { copy(isShowLogoutDialog = false) }
+                tokenRepository.clearTokensWithAuthCache()
+                postSideEffect(MyPageEffect.LogoutWithKakao)
+            }
+            .onFailure { Timber.e(it, "Failed to logout from server") }
     }
 
     private fun withdrawAccount(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,6 +74,7 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycleViewModel" }
 
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
+kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutines" }
 
 androidx-paging-common = { group = "androidx.paging", name = "paging-common", version.ref = "paging" }
 androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }
@@ -124,6 +125,7 @@ oss-licenses = { group = "com.google.android.gms", name = "play-services-oss-lic
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging" }
 
 # Dependencies of the included build-logic
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -74,7 +74,6 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycleViewModel" }
 
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
-kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutines" }
 
 androidx-paging-common = { group = "androidx.paging", name = "paging-common", version.ref = "paging" }
 androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }


### PR DESCRIPTION
## 🔗 관련 이슈
- Close #211

## 📙 작업 설명
- FCM 의존성 추가 및 `NekiFirebaseMessagingService` 구현
- 포그라운드/백그라운드 메시지 수신 시 헤드업 알림 표시
- 토큰 갱신(`onNewToken()`) 시 로컬 저장 후 푸시 토큰 서버 전송 시점을 홈(아카이빙 메인) 진입으로 통합(약관, 로그인, 스플래시 분리하지 않고 한 번만 처리하기 위함)
- `TokenRepository` 복호화 실패 시 예외 처리 추가

## 🧪 테스트 내역
- [x] 앱 설치 후 FCM 토큰 서버 전송 확인
- [x] 포그라운드/백그라운드 상태에서 푸시 알림 수신 및 헤드업 알림 확인
- [x] 개발기/상용기 푸시 알림 정상 수신 확인

## 📸 스크린샷 또는 시연 영상 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Firebase Cloud Messaging 기반 푸시 알림 수신 및 알림 채널 적용이 추가되었습니다.
  * 푸시 토큰 저장/갱신과 알림 권한 동의 상태에 따른 알림 설정 반영이 추가되었습니다.
* **Bug Fixes**
  * 토큰 복호화 과정에서 예외가 발생해도 앱이 중단되지 않도록 처리하고, 오류 시 안전하게 정리/기본값을 반환하도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->